### PR TITLE
Hostname in query-example does'nt exist in ingested records

### DIFF
--- a/sample_apps/js/query-example.js
+++ b/sample_apps/js/query-example.js
@@ -1,7 +1,7 @@
 
 const constants = require('./constants');
 
-const HOSTNAME = "host-24Gju";
+const HOSTNAME = "host1";
 
 // See records ingested into this table so far
 const SELECT_ALL_QUERY = "SELECT * FROM " +  constants.DATABASE_NAME + "." +  constants.TABLE_NAME;


### PR DESCRIPTION
**Fix for Issue:** https://github.com/awslabs/amazon-timestream-tools/issues/45 reported by @ron2911 

**What is the fix:**
updated hostname as 'host1'  in file query-example.js

**How fix was it verified:** 
1) ran 
node main.js

**Output:**
I can see queries returning results that match hostname = 'host1' 

{region=us-east-1, az=az1, **hostname=host1,** binned_timestamp=2020-12-03 07:06:15.000000000, avg_cpu_utilization=13.83, p90_cpu_utilization=14.5, p95_cpu_utilization=14.5, p99_cpu_utilization=14.5}
{region=us-east-1, az=az1, **hostname=host1**, binned_timestamp=2020-12-03 07:09:00.000000000, avg_cpu_utilization=13.83, p90_cpu_utilization=14.5, p95_cpu_utilization=14.5, p99_cpu_utilization=14.5}


