### PR TITLE
Replace os.mkdir() with os.makedirs() to create directory path recursively

### DIFF
--- a/tools/perf-scale-workload/query_executer.py
+++ b/tools/perf-scale-workload/query_executer.py
@@ -136,13 +136,13 @@ class RandomizedExecutionThread(threading.Thread):
         runPrefix = self.args.runPrefix
 
         if not os.path.exists(logDir):
-            os.mkdir(logDir)
+            os.makedirs(logDir)
 
         ## Create an experiment name for logging purposes.
         expName = "{}-{}-{}".format(runPrefix, self.startTime.strftime("%Y-%m-%d-%H-%M-%S"), self.threadId)
         expDirName = os.path.join(logDir, expName)
         if not os.path.exists(expDirName):
-            os.mkdir(expDirName)
+            os.makedirs(expDirName)
 
         print("Starting experiment {} at {}. Database: {}. Table: {}. Log files at: {}".format(
             expName, self.startTime, databaseName, tableName, expDirName))


### PR DESCRIPTION
Issue: Query workload sample command listed in [Readme](https://github.com/awslabs/amazon-timestream-tools/blob/master/tools/perf-scale-workload/README.md) was failing because it would not create directory ~/experiment_log/r1

Fix:
Replace os.mkdir() with [os.makedirs() ](https://docs.python.org/3/library/os.html)to create directory path recursively