### PR TITLE
Updating guava dependency to 30.0-jre

### DIFF
--- a/sample_apps/jdbc/pom.xml
+++ b/sample_apps/jdbc/pom.xml
@@ -29,7 +29,7 @@
         <dependency>
           <groupId>com.google.guava</groupId>
           <artifactId>guava</artifactId>
-          <version>29.0-jre</version>
+          <version>30.0-jre</version>
         </dependency>
         <dependency>
           <groupId>org.slf4j</groupId>


### PR DESCRIPTION
Current version has 'moderate' security risk associated as flagged by Dependabot.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
