### PR TITLE
Adding IoT topic rule to CFN template

### DIFF
--- a/integrations/iot_core/README.md
+++ b/integrations/iot_core/README.md
@@ -16,6 +16,9 @@ The CloudFormation template creates:
 ### AWS Region
 **Note** The instructions in this repository will use the US East (N. Virginia) Region (us-east-1). If you want to choose another region replace the region in the instructions with the region of your choice. You need also replace the region then in the data generating script `sensordata.py`.
 
+### AWS Command Line Interface
+You must use an AWS Command Line Interface (AWS CLI) version which supports timestream and the timestream action for an iot rule. This applies as of version **2.0.54** for the [AWS CLI version 2](https://docs.aws.amazon.com/cli/latest/userguide/cli-chap-install.html#cli-chap-install-v2) and as of version **1.18.150** for the former version of the AWS CLI.
+
 ### Sample data generation script
 The data generation script generates sample data that represent fictitious sensors in buildings which measure humidity, barometric pressure and temperature. 
 

--- a/integrations/iot_core/cfn-iot-rule-to-timestream.json
+++ b/integrations/iot_core/cfn-iot-rule-to-timestream.json
@@ -1,80 +1,165 @@
 {
   "Description": "AWS IoT Core and Amazon Timestream integration.",
-
   "Resources": {
-    "TimestreamDataBase": {
-      "Type" : "AWS::Timestream::Database"
-    },
-
-    "TimestreamTable": {
-      "Type" : "AWS::Timestream::Table",
-      "Properties" : {
-          "DatabaseName" : {"Ref": "TimestreamDataBase"},
-          "RetentionProperties" : {
-            "MemoryStoreRetentionPeriodInHours" : "24",
-            "MagneticStoreRetentionPeriodInDays" : "5"
-        }
+      "TimestreamDataBase": {
+          "Type": "AWS::Timestream::Database"
+      },
+      "TimestreamTable": {
+          "Type": "AWS::Timestream::Table",
+          "Properties": {
+              "DatabaseName": {
+                  "Ref": "TimestreamDataBase"
+              },
+              "RetentionProperties": {
+                  "MemoryStoreRetentionPeriodInHours": "24",
+                  "MagneticStoreRetentionPeriodInDays": "5"
+              }
+          }
+      },
+      "IoTDataRule": {
+          "Type": "AWS::IoT::TopicRule",
+          "Properties": {
+              "TopicRulePayload": {
+                  "RuleDisabled": false,
+                  "Actions": [
+                      {
+                          "Timestream": {
+                              "RoleArn": {
+                                  "Fn::GetAtt": [
+                                      "IoTDataToTimestreamRole",
+                                      "Arn"
+                                  ]
+                              },
+                              "DatabaseName": {
+                                  "Ref": "TimestreamDataBase"
+                              },
+                              "TableName": {
+                                  "Fn::Select": [
+                                      1,
+                                      {
+                                          "Fn::Split": [
+                                              "|",
+                                              {
+                                                  "Ref": "TimestreamTable"
+                                              }
+                                          ]
+                                      }
+                                  ]
+                              },
+                              "Dimensions": [
+                                  {
+                                      "Name": "device_id",
+                                      "Value": "${device_id}"
+                                  },
+                                  {
+                                      "Name": "building",
+                                      "Value": "${building}"
+                                  },
+                                  {
+                                      "Name": "room",
+                                      "Value": "${room}"
+                                  }
+                              ]
+                          }
+                      }
+                  ],
+                  "Sql": "SELECT humidity, pressure, temperature FROM 'dt/sensor/#'"
+              }
+          }
+      },
+      "IoTDataToTimestreamRole": {
+          "Type": "AWS::IAM::Role",
+          "Properties": {
+              "AssumeRolePolicyDocument": {
+                  "Statement": [
+                      {
+                          "Effect": "Allow",
+                          "Principal": {
+                              "Service": [
+                                  "iot.amazonaws.com"
+                              ]
+                          },
+                          "Action": [
+                              "sts:AssumeRole"
+                          ]
+                      }
+                  ]
+              },
+              "Policies": [
+                  {
+                      "PolicyName": {
+                          "Fn::Join": [
+                              "",
+                              [
+                                  "IoTDataToTimestreamInlinePolicy-",
+                                  {
+                                      "Ref": "AWS::Region"
+                                  }
+                              ]
+                          ]
+                      },
+                      "PolicyDocument": {
+                          "Version": "2012-10-17",
+                          "Statement": [
+                              {
+                                  "Effect": "Allow",
+                                  "Action": [
+                                      "timestream:WriteRecords"
+                                  ],
+                                  "Resource": [
+                                      {
+                                          "Fn::GetAtt": [
+                                              "TimestreamTable",
+                                              "Arn"
+                                          ]
+                                      }
+                                  ]
+                              },
+                              {
+                                  "Effect": "Allow",
+                                  "Action": [
+                                      "timestream:DescribeEndpoints"
+                                  ],
+                                  "Resource": "*"
+                              }
+                          ]
+                      }
+                  }
+              ],
+              "Path": "/service-role/"
+          }
       }
-    },
-
-    "IoTDataToTimestreamRole": {
-       "Type": "AWS::IAM::Role",
-       "Properties": {
-          "AssumeRolePolicyDocument": {
-             "Statement": [ {
-                "Effect": "Allow",
-                "Principal": {
-                   "Service": [ "iot.amazonaws.com" ]
-                },
-                "Action": [ "sts:AssumeRole" ]
-             } ]
-          },
-          "Policies": [ {
-             "PolicyName": {"Fn::Join": ["", ["IoTDataToTimestreamInlinePolicy-", {"Ref": "AWS::Region"} ]]},
-             "PolicyDocument": {
-                 "Version":"2012-10-17",
-                 "Statement": [
-                    {
-                       "Effect":"Allow",
-                       "Action": [
-                         "timestream:WriteRecords"
-                       ],
-                       "Resource": [
-                         { "Fn::GetAtt": ["TimestreamTable", "Arn"] }
-                       ]
-                    },
-                    {
-                        "Effect": "Allow",
-                        "Action": [
-                            "timestream:DescribeEndpoints"
-                        ],
-                        "Resource": "*"
-                    }
-                 ]
-               }
-             }
-           ],
-          "Path": "/service-role/"
-        }
-    }
   },
-
-  "Outputs" : {
-    "TimestreamDataBaseName": {
-      "Description" : "Timestream data base name",
-      "Value" : { "Ref": "TimestreamDataBase" }
-    },
-    "TimestreamTableName": {
-      "Description" : "Timestream table name",
-      "Value" : { "Ref": "TimestreamTable" }
-    },
-    "TimestreamTableArn": {
-      "Description" : "Timestream table arn",
-      "Value" : { "Fn::GetAtt": ["TimestreamTable", "Arn"] }
-    },
-    "IoTDataToTimestreamRoleArn": {
-      "Description": "Arn for the IAM role to allow write to Timestream table",
-      "Value": { "Fn::GetAtt": ["IoTDataToTimestreamRole", "Arn"] }
-    }
+  "Outputs": {
+      "TimestreamDataBaseName": {
+          "Description": "Timestream data base name",
+          "Value": {
+              "Ref": "TimestreamDataBase"
+          }
+      },
+      "TimestreamTableName": {
+          "Description": "Timestream table name",
+          "Value": {
+              "Ref": "TimestreamTable"
+          }
+      },
+      "TimestreamTableArn": {
+          "Description": "Timestream table arn",
+          "Value": {
+              "Fn::GetAtt": [
+                  "TimestreamTable",
+                  "Arn"
+              ]
+          }
+      },
+      "IoTDataToTimestreamRoleArn": {
+          "Description": "Arn for the IAM role to allow write to Timestream table",
+          "Value": {
+              "Fn::GetAtt": [
+                  "IoTDataToTimestreamRole",
+                  "Arn"
+              ]
+          }
+      }
   }
 }


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Creating IoT TopicRule with a Timestream action is now supported in CFN, updating this example to demonstrate it.

Tested the example end to end with sensor publishing data into Timestream.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
