### PR TITLE
Update recent aws-sdk version dependencies

### DIFF
--- a/sample_apps/dotnet/README.md
+++ b/sample_apps/dotnet/README.md
@@ -18,7 +18,7 @@ This sample application shows how you can create a database and table, populate 
    ```
 
 3. Install required NuGet. Ensure AWSSDK.Core version is 3.3.107 or newer.
-   ```shell
+   ```
    dotnet add package AWSSDK.Core
    dotnet add package AWSSDK.TimestreamWrite
    dotnet add package AWSSDK.TimestreamQuery 
@@ -26,7 +26,7 @@ This sample application shows how you can create a database and table, populate 
    ```
 
 4. Run the project
-   ```shell
+   ```
    dotnet run
    ```
    
@@ -36,34 +36,6 @@ This sample application shows how you can create a database and table, populate 
    ```
 
 6. Run with sample csv data file
-   ```shell
+   ```
    dotnet run -- -f ../data/sample.csv
    ```
-
-
-
-# Updated instructions
-
-1. Install [.NET](https://docs.microsoft.com/en-us/dotnet/core/install/) 
-wget https://dot.net/v1/dotnet-install.sh
-sh ./dotnet-install.sh  
-
-export PATH=$PATH:/home/ec2-user/.dotnet
-
-2. Run the project
-   ```shell
-   dotnet run
-   ```
-   
-3. Run with kms key id for Update database
-   ```
-   dotnet run -- -k ValidKmsKeyId
-   ```
-
-4. Run with sample csv data file
-   ```shell
-   dotnet run -- -f ../data/sample.csv
-   ```
-
-
-

--- a/sample_apps/dotnet/README.md
+++ b/sample_apps/dotnet/README.md
@@ -13,6 +13,7 @@ This sample application shows how you can create a database and table, populate 
    dotnet remove package AWSSDK.Core
    dotnet remove package AWSSDK.TimestreamWrite
    dotnet remove package AWSSDK.TimestreamQuery
+   dotnet remove package CommandLineParser
    dotnet nuget locals all --clear
    ```
 
@@ -38,4 +39,31 @@ This sample application shows how you can create a database and table, populate 
    ```shell
    dotnet run -- -f ../data/sample.csv
    ```
+
+
+
+# Updated instructions
+
+1. Install [.NET](https://docs.microsoft.com/en-us/dotnet/core/install/) 
+wget https://dot.net/v1/dotnet-install.sh
+sh ./dotnet-install.sh  
+
+export PATH=$PATH:/home/ec2-user/.dotnet
+
+2. Run the project
+   ```shell
+   dotnet run
+   ```
+   
+3. Run with kms key id for Update database
+   ```
+   dotnet run -- -k ValidKmsKeyId
+   ```
+
+4. Run with sample csv data file
+   ```shell
+   dotnet run -- -f ../data/sample.csv
+   ```
+
+
 

--- a/sample_apps/dotnet/TimestreamDotNetSample.csproj
+++ b/sample_apps/dotnet/TimestreamDotNetSample.csproj
@@ -1,12 +1,12 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp5.0</TargetFramework>
+    <TargetFramework>netcoreapp6.0</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="AWSSDK.Core" Version="3.5.1.42" />
-    <PackageReference Include="AWSSDK.TimestreamQuery" Version="3.5.1.1" />
-    <PackageReference Include="AWSSDK.TimestreamWrite" Version="3.5.1" />
+    <PackageReference Include="AWSSDK.Core" Version="3.7.5.2" />
+    <PackageReference Include="AWSSDK.TimestreamQuery" Version="3.7.1" />
+    <PackageReference Include="AWSSDK.TimestreamWrite" Version="3.7.1" />
     <PackageReference Include="CommandLineParser" Version="2.8.0" />
   </ItemGroup>
 </Project>

--- a/sample_apps/java/pom.xml
+++ b/sample_apps/java/pom.xml
@@ -17,7 +17,7 @@
             <dependency>
                 <groupId>com.amazonaws</groupId>
                 <artifactId>aws-java-sdk-bom</artifactId>
-                <version>1.11.908</version>
+                <version>1.12.118</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/sample_apps/javaV2/pom.xml
+++ b/sample_apps/javaV2/pom.xml
@@ -15,7 +15,7 @@
             <dependency>
                 <groupId>software.amazon.awssdk</groupId>
                 <artifactId>bom</artifactId>
-                <version>2.15.35</version>
+                <version>2.17.89</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>

--- a/sample_apps/js/package-lock.json
+++ b/sample_apps/js/package-lock.json
@@ -9,14 +9,14 @@
       "version": "1.0.0",
       "license": "ISC",
       "dependencies": {
-        "aws-sdk": "^2.842.0",
+        "aws-sdk": "^2.1036.0",
         "minimist": "^1.2.5"
       }
     },
     "node_modules/aws-sdk": {
-      "version": "2.842.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.842.0.tgz",
-      "integrity": "sha512-9vjVDxsLzNI79JChUgEHDUpv2obkTe35F3oGFGViKsf4C7xlOexzKOCfTRNcgzh0MON6rVDFpYBtF2LlEyDGKg==",
+      "version": "2.1036.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1036.0.tgz",
+      "integrity": "sha512-K0f4uXL32ZdoPmWiuSQEAC5ae5v7gNmhjzoEB7VonE5E8l2umWsoU0Ahm8WPr14LgsvtkeyBuqBjphbxLz6hIw==",
       "dependencies": {
         "buffer": "4.9.2",
         "events": "1.1.1",
@@ -29,7 +29,7 @@
         "xml2js": "0.4.19"
       },
       "engines": {
-        "node": ">= 0.8.0"
+        "node": ">= 10.0.0"
       }
     },
     "node_modules/base64-js": {
@@ -147,9 +147,9 @@
   },
   "dependencies": {
     "aws-sdk": {
-      "version": "2.842.0",
-      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.842.0.tgz",
-      "integrity": "sha512-9vjVDxsLzNI79JChUgEHDUpv2obkTe35F3oGFGViKsf4C7xlOexzKOCfTRNcgzh0MON6rVDFpYBtF2LlEyDGKg==",
+      "version": "2.1036.0",
+      "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.1036.0.tgz",
+      "integrity": "sha512-K0f4uXL32ZdoPmWiuSQEAC5ae5v7gNmhjzoEB7VonE5E8l2umWsoU0Ahm8WPr14LgsvtkeyBuqBjphbxLz6hIw==",
       "requires": {
         "buffer": "4.9.2",
         "events": "1.1.1",

--- a/sample_apps/js/package.json
+++ b/sample_apps/js/package.json
@@ -18,7 +18,7 @@
   },
   "homepage": "https://github.com/awslabs/amazon-timestream-tools/tree/master/sample_apps/js#readme",
   "dependencies": {
-    "aws-sdk": "^2.842.0",
+    "aws-sdk": "^2.1036.0",
     "minimist": "^1.2.5"
   }
 }


### PR DESCRIPTION
Changes:
- Dotnet project to use .NET SDK 6.0 and AWS SDK 3.7.5.2
-  Updated DotNet's README that has instructions to remove older CommandLineParse
- Java V1 SDK migrate to 1.12.118 and JavaV2 SDK migrate to 2.17.89
- Javascript - aws-sdk version migrate to 2.1036.0

Manual Testing:
1) Compiled DotNet project using .NET 6.0 on AL2  and ran the sample - PASSED
2) Installed  Maven 3.8.4 and compiled Java V1 sample on AL2 & ran the sample - PASSED
3) Installed  Maven 3.8.4 and compiled Java V2 sample on AL2 & ran the sample - PASSED
4) Installed NPM dependency - aws-sdk version - 2.1036.0 and ran Javascript sample  - PASSED
5) Installed Python boto3(1.20.13) dependency in virtual environment and ran Python sample  - PASSED
