### PR TITLE
pass region when creating AWS resources, improve error handling

### DIFF
--- a/sample_apps_reinvent2021/python/README.md
+++ b/sample_apps_reinvent2021/python/README.md
@@ -68,7 +68,7 @@ python3 SampleApplication.py \
 --region us-east-2 \
 --skip_deletion false
 ```
-Note: If skip_deletion is true then ScheduledQuery resources (s3 buckets, iam role, timestream scheduled-query etc) needs to be deleted manually.
+Note: If skip_deletion is true then ScheduledQuery resources (Timestream scheduled query, Timestream database, Timestream table, SNS, SQS, IAM role, IAM policy, S3) need to be deleted manually.
 
 ### Run example to create scheduled query that fails on execution and generates an error report
 ```

--- a/sample_apps_reinvent2021/python/SampleApplication.py
+++ b/sample_apps_reinvent2021/python/SampleApplication.py
@@ -13,7 +13,7 @@ from examples.ScheduledQueryExample import ScheduledQueryExample
 from examples.Cleanup import Cleanup
 
 
-def main(app_type, csv_file_path, kms_id, stage, cell, region, skip_deletion_string):
+def main(app_type, csv_file_path, kms_id, stage, region, skip_deletion_string):
     session = boto3.Session()
     skip_deletion = skip_deletion_string == "true"
 
@@ -92,7 +92,6 @@ if __name__ == '__main__':
     parser.add_argument("-f", "--csv_file_path", help="file to ingest")
     parser.add_argument("-k", "--kmsId", help="KMS key for updating the database")
     parser.add_argument("-s", "--stage", default="prod")
-    parser.add_argument("-c", "--cell", default="cell1")
     parser.add_argument("-r", "--region", default="us-east-1")
     parser.add_argument("-sd",
                         "--skip_deletion",
@@ -101,4 +100,4 @@ if __name__ == '__main__':
                         help="skip deletion of table and database created by this script")
     args = parser.parse_args()
 
-    main(args.type, args.csv_file_path, args.kmsId, args.stage, args.cell, args.region, args.skip_deletion)
+    main(args.type, args.csv_file_path, args.kmsId, args.stage, args.region, args.skip_deletion)


### PR DESCRIPTION
## Description
This PR
- fixes a bug in the Scheduled Query example by creating resources in the correct AWS region instead of the default region
- improves error handling by avoiding premature failures. Consecutive runs with & without `--skip_deletion` now succeed

## Testing
```bash
# verify that changing regions works
python SampleApplication.py --type sq --region us-west-2 --skip_deletion false
python SampleApplication.py --type sq --region us-east-1 --skip_deletion false
python SampleApplication.py --type sq --region us-east-2 --skip_deletion false

# verify that _not_ cleaning up works
python SampleApplication.py --type sq --region us-west-2 --skip_deletion true
python SampleApplication.py --type sq --region us-west-2 --skip_deletion true
python SampleApplication.py --type sq --region us-west-2 --skip_deletion false
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
