### PR TITLE
Adding support for multi-measure records for the performance and scale workload

### DIFF
--- a/tools/perf-scale-workload/README.md
+++ b/tools/perf-scale-workload/README.md
@@ -63,7 +63,11 @@ sudo yum install python3-devel
 
 ## Authentication and Authorization
 
-Timestream uses IAM-based authentication and authorization. Each of the driver scripts here is configured to obtain the credentials using the default credentials provider. They also support providing an explicit profile (configured through ``aws configure``) using the ``--profile`` argument. [Follow the instructions](https://docs.aws.amazon.com/timestream/latest/developerguide/accessing.html#getting-started.prereqs.iam-user) to make sure that IAM profile as the necessary access.
+Timestream uses IAM-based authentication and authorization. Each of the driver scripts here is configured to obtain the credentials using the default credentials provider. They also support providing an explicit profile (configured through ``aws configure``) using the ``--profile`` argument. [Follow the instructions](https://docs.aws.amazon.com/timestream/latest/developerguide/accessing.html#getting-started.prereqs.iam-user) to make sure that IAM profile has the necessary access.
+
+## Data model - Single-measure vs. Multi-measure records
+
+Timestream allows you to store your measures either as single measure per record or multiple measures per record. Multi-measure records are suited when multiple measurements are emitted at the same time instant. You can control the data model for the ingester and the query workload generator using the ``--multi`` argument in the scripts.
 
 ## Ingestion Workload
 
@@ -75,11 +79,15 @@ A multi-process and multi-threaded application models the metrics and events emi
 python3 devops_ingestion_driver.py --help
 ```
 
-In addition to specifying the Timestream database and table, the table's [retention bounds](https://docs.aws.amazon.com/timestream/latest/developerguide/storage.html), and the AWS region, the arguments also control the data scale, ingestion volume, and the concurrency of the workload driver. The ``--memory-store-retention-hours`` and ``--magnetic-store-retention-days`` options allow overriding the retention bounds desired. Note that these options are only effective if the table is created by the script. If the table already exists, the script down not modify its existing retention bounds.
+In addition to specifying the Timestream database and table, the table's [retention bounds](https://docs.aws.amazon.com/timestream/latest/developerguide/storage.html), and the AWS region, the arguments also control the data scale, ingestion volume, and the concurrency of the workload driver. The ``--memory-store-retention-hours`` and ``--magnetic-store-retention-days`` options allow overriding the retention bounds desired. Note that these options are only effective if the table is created by the script. If the table already exists, the script does not modify its existing retention bounds.
 
 At a high level, the data generator models (defined in ``model.py``) multiple hosts within the service. The option ``--host-scale`` determines the number of hosts emitting metrics. ``--host-scale 1`` corresponds to 1,000 hosts emitting metrics, ``--host-scale 100`` corresponds to 100,000 hosts and so on.
 
-Each host emits 26 periodic metrics and events that correspond to resource usage, GC events, etc. Therefore, ``--host-scale 100`` corresponds to 2.6M time series being stored in the table.
+### Data model for metrics and Events
+
+Each host emits 26 periodic metrics and events that correspond to resource usage, GC events, etc. The data generator supports two different modes for data modeling:
+* **Single-measure records**: In this mode, each metric or event has its own measure name and row in the table. The values are stored in scalar measure values in the Timestream table, and accessed as ``measure_value::double``, ``measure_value::bigint``, ``measure_value::varchar`` etc. Therefore, ``--host-scale 100`` corresponds to 2.6M time series being stored in the table. This is **default** model for the scripts.
+* **Multi-measure records**: In this mode, 20 metrics are emitted in row and use the measure name ``metric`` while the 5 events (``gc_pause``, ``gc_reclaimed``, ``memory_free``, ``task_completed``, ``task_end_state``) are emitted with measure name ``event``. This mode is enabled with a separate option when ingesting (``--multi``). ``--host-scale 100`` corresponds to 220K time series being stored in the table.
 
 The other parameter that controls the ingestion volume is the interval at which metrics and events are emitted. The argument ``--interval-millis`` controls this interval. ``--interval-millis 60000`` implies that each host emits its set of metrics and events once every 60 seconds on average.
 
@@ -87,19 +95,30 @@ The table below summarizes some example configurations for ``--host-scale`` and 
 
 ### Table summarizing sample parameters
 
-|   |Interval Millis (ms)	|Host scale	|Number of hosts	|Num of Time series	|Avg. Data points/sec	|Avg. Data points/hr	|Avg. Ingestion volume (MB/s)	|Data size per hour (GB)	|Data size per day (GB)	|Data size per year (TB)	|
+**Single-measure records**
+
+|   |Interval Millis (ms)	|Host scale	|Number of hosts	|Num of Time series	|Avg. rows points/sec	|Avg. row points/hr	|Avg. Ingestion volume (MB/s)	|Data size per hour (GB)	|Data size per day (GB)	|Data size per year (TB)	|
 |---    |---	|---	|---	|---	|---	|---	|---	|---	|---	|---	|
 |**Small**|60,000	|100	|100,000	|2,600,000	|43,333	|155,998,800	|12.86	|45	|1,085	|387	|
 |**Medium**|300,000	|2,000	|2,000,000	|52,000,000	|173,333	|623,998,800	|51.45	|181	|4,341	|1,547	|
 |**Large**|120,000	|4,000	|4,000,000	|104,000,000	|866,667	|3,120,001,200	|257.26	|904	|21,706	|7,737	|
 
+**Multi-measure records**
+
+|   |Interval Millis (ms)	|Host scale	|Number of hosts	|Num of Time series	|Avg. rows points/sec	|Avg. rows points/hr	|Avg. Ingestion volume (MB/s)	|Data size per hour (GB)	|Data size per day (GB)	|Data size per year (TB)	|
+|---    |---	|---	|---	|---	|---	|---	|---	|---	|---	|---	|
+|**Small**|60,000	|100	|100,000	|220,000	|3,667	|13,201,200	|1.78	|6.26	|150	|54	|
+|**Medium**|300,000	|2,000	|2,000,000	|4,400,000	|14,667	|52,801,200	|7.11	|25	|600	|214	|
+|**Large**|120,000	|4,000	|4,000,000	|8,800,000	|73,333	|263,998,800	|35.57	|125	|3,001	|1,069	|
+
+
 The above output can also be generated using the ``--print-model-summary`` argument for the script. Note that passing this argument does not execute the ingestion process, it only prints the summary and the script exits. For example:
 
 ```
-python3 devops_ingestion_driver.py -d perf_scale -t test -e us-east-1 -c 10 -p 5 --host-scale 100 --interval-millis 60000 --print-model-summary
+python3 devops_ingestion_driver.py -d perf_scale -t test -r us-east-1 -c 10 -p 5 --host-scale 100 --interval-millis 60000 --print-model-summary
 ```
 
-The above command generates the following output summarizing the (approximate) ingestion and data volume characteristics.
+The above command generates the following output summarizing the (approximate) ingestion and data volume characteristics. Note that the default for the script is the single measure model, so the output below corresponds to that.
 
 ```
 Dimensions for metrics: 100,000
@@ -109,18 +128,155 @@ Number of timeseries: 2,600,000. Avg. data points per second: 43,333. Avg. data 
 Avg. Ingestion volume: 12.86 MB/s. Data size per hour: 45.21 GB. Data size per day: 1,085.04 GB. Data size per year: 386.76 TB
 ```
 
+To generate the same output for the multi-measure data model, we need to execute the same command with the ``--multi`` parameter.
+
+```
+python3 devops_ingestion_driver.py -d perf_scale -t test -r us-east-1 -c 10 -p 5 --host-scale 100 --interval-millis 60000 --multi --print-model-summary
+```
+
+This will in turn generate the output:
+
+```
+Dimensions for metrics: 100,000
+Dimensions for events: 120,000
+Dimension bytes: Events: 282, Metrics: 284
+Bytes for names: Metrics: 234, Events: 59
+avg row size: 508.99 Bytes
+Number of timeseries: 220,000. Avg. data points per second: 3,667. Avg. no. of metrics per second: 43,333 Avg. data points per hour: 13,201,200
+Avg. Ingestion volume: 1.78 MB/s. Data size per hour: 6.26 GB. Data size per day: 150.24 GB. Data size per year: 53.55 TB
+```
+
+### Table schema with single-measure records
+
+Below is the table schema when the metrics are stored using single-measure records.
+
+```
+DESCRIBE db.table
+```
+
+|Column	|Type	|Timestream attribute type	|
+|---	|---	|---	|
+|availability_zone	|varchar	|DIMENSION	|
+|microservice_name	|varchar	|DIMENSION	|
+|instance_name	|varchar	|DIMENSION	|
+|process_name	|varchar	|DIMENSION	|
+|os_version	|varchar	|DIMENSION	|
+|jdk_version	|varchar	|DIMENSION	|
+|cell	|varchar	|DIMENSION	|
+|region	|varchar	|DIMENSION	|
+|silo	|varchar	|DIMENSION	|
+|instance_type	|varchar	|DIMENSION	|
+|measure_name	|varchar	|MEASURE_NAME	|
+|time	|timestamp	|TIMESTAMP	|
+|measure_value::double	|double	|MEASURE_VALUE	|
+|measure_value::bigint	|bigint	|MEASURE_VALUE	|
+|measure_value::varchar	|varchar	|MEASURE_VALUE	|
+
+Below is the measure schema, i.e., the mapping of the measures to dimensions.
+
+```
+SHOW MEASURES FROM db.table
+```
+
+|measure_name	|data_type	|dimensions	|
+|---	|---	|---	|
+|cpu_hi	|double	|[{'dimension_name': 'availability_zone', 'data_type': 'varchar'}, {'dimension_name': 'microservice_name', 'data_type': 'varchar'}, {'dimension_name': 'instance_name', 'data_type': 'varchar'}, {'dimension_name': 'os_version', 'data_type': 'varchar'}, {'dimension_name': 'cell', 'data_type': 'varchar'}, {'dimension_name': 'region', 'data_type': 'varchar'}, {'dimension_name': 'silo', 'data_type': 'varchar'}, {'dimension_name': 'instance_type', 'data_type': 'varchar'}]	|
+|cpu_idle	|double	|[{'dimension_name': 'availability_zone', 'data_type': 'varchar'}, {'dimension_name': 'microservice_name', 'data_type': 'varchar'}, {'dimension_name': 'instance_name', 'data_type': 'varchar'}, {'dimension_name': 'os_version', 'data_type': 'varchar'}, {'dimension_name': 'cell', 'data_type': 'varchar'}, {'dimension_name': 'region', 'data_type': 'varchar'}, {'dimension_name': 'silo', 'data_type': 'varchar'}, {'dimension_name': 'instance_type', 'data_type': 'varchar'}]	|
+|cpu_iowait	|double	|[{'dimension_name': 'availability_zone', 'data_type': 'varchar'}, {'dimension_name': 'microservice_name', 'data_type': 'varchar'}, {'dimension_name': 'instance_name', 'data_type': 'varchar'}, {'dimension_name': 'os_version', 'data_type': 'varchar'}, {'dimension_name': 'cell', 'data_type': 'varchar'}, {'dimension_name': 'region', 'data_type': 'varchar'}, {'dimension_name': 'silo', 'data_type': 'varchar'}, {'dimension_name': 'instance_type', 'data_type': 'varchar'}]	|
+|cpu_nice	|double	|[{'dimension_name': 'availability_zone', 'data_type': 'varchar'}, {'dimension_name': 'microservice_name', 'data_type': 'varchar'}, {'dimension_name': 'instance_name', 'data_type': 'varchar'}, {'dimension_name': 'os_version', 'data_type': 'varchar'}, {'dimension_name': 'cell', 'data_type': 'varchar'}, {'dimension_name': 'region', 'data_type': 'varchar'}, {'dimension_name': 'silo', 'data_type': 'varchar'}, {'dimension_name': 'instance_type', 'data_type': 'varchar'}]	|
+|cpu_si	|double	|[{'dimension_name': 'availability_zone', 'data_type': 'varchar'}, {'dimension_name': 'microservice_name', 'data_type': 'varchar'}, {'dimension_name': 'instance_name', 'data_type': 'varchar'}, {'dimension_name': 'os_version', 'data_type': 'varchar'}, {'dimension_name': 'cell', 'data_type': 'varchar'}, {'dimension_name': 'region', 'data_type': 'varchar'}, {'dimension_name': 'silo', 'data_type': 'varchar'}, {'dimension_name': 'instance_type', 'data_type': 'varchar'}]	|
+|cpu_steal	|double	|[{'dimension_name': 'availability_zone', 'data_type': 'varchar'}, {'dimension_name': 'microservice_name', 'data_type': 'varchar'}, {'dimension_name': 'instance_name', 'data_type': 'varchar'}, {'dimension_name': 'os_version', 'data_type': 'varchar'}, {'dimension_name': 'cell', 'data_type': 'varchar'}, {'dimension_name': 'region', 'data_type': 'varchar'}, {'dimension_name': 'silo', 'data_type': 'varchar'}, {'dimension_name': 'instance_type', 'data_type': 'varchar'}]	|
+|cpu_system	|double	|[{'dimension_name': 'availability_zone', 'data_type': 'varchar'}, {'dimension_name': 'microservice_name', 'data_type': 'varchar'}, {'dimension_name': 'instance_name', 'data_type': 'varchar'}, {'dimension_name': 'os_version', 'data_type': 'varchar'}, {'dimension_name': 'cell', 'data_type': 'varchar'}, {'dimension_name': 'region', 'data_type': 'varchar'}, {'dimension_name': 'silo', 'data_type': 'varchar'}, {'dimension_name': 'instance_type', 'data_type': 'varchar'}]	|
+|cpu_user	|double	|[{'dimension_name': 'availability_zone', 'data_type': 'varchar'}, {'dimension_name': 'microservice_name', 'data_type': 'varchar'}, {'dimension_name': 'instance_name', 'data_type': 'varchar'}, {'dimension_name': 'os_version', 'data_type': 'varchar'}, {'dimension_name': 'cell', 'data_type': 'varchar'}, {'dimension_name': 'region', 'data_type': 'varchar'}, {'dimension_name': 'silo', 'data_type': 'varchar'}, {'dimension_name': 'instance_type', 'data_type': 'varchar'}]	|
+|disk_free	|double	|[{'dimension_name': 'availability_zone', 'data_type': 'varchar'}, {'dimension_name': 'microservice_name', 'data_type': 'varchar'}, {'dimension_name': 'instance_name', 'data_type': 'varchar'}, {'dimension_name': 'os_version', 'data_type': 'varchar'}, {'dimension_name': 'cell', 'data_type': 'varchar'}, {'dimension_name': 'region', 'data_type': 'varchar'}, {'dimension_name': 'silo', 'data_type': 'varchar'}, {'dimension_name': 'instance_type', 'data_type': 'varchar'}]	|
+|disk_io_reads	|double	|[{'dimension_name': 'availability_zone', 'data_type': 'varchar'}, {'dimension_name': 'microservice_name', 'data_type': 'varchar'}, {'dimension_name': 'instance_name', 'data_type': 'varchar'}, {'dimension_name': 'os_version', 'data_type': 'varchar'}, {'dimension_name': 'cell', 'data_type': 'varchar'}, {'dimension_name': 'region', 'data_type': 'varchar'}, {'dimension_name': 'silo', 'data_type': 'varchar'}, {'dimension_name': 'instance_type', 'data_type': 'varchar'}]	|
+|disk_io_writes	|double	|[{'dimension_name': 'availability_zone', 'data_type': 'varchar'}, {'dimension_name': 'microservice_name', 'data_type': 'varchar'}, {'dimension_name': 'instance_name', 'data_type': 'varchar'}, {'dimension_name': 'os_version', 'data_type': 'varchar'}, {'dimension_name': 'cell', 'data_type': 'varchar'}, {'dimension_name': 'region', 'data_type': 'varchar'}, {'dimension_name': 'silo', 'data_type': 'varchar'}, {'dimension_name': 'instance_type', 'data_type': 'varchar'}]	|
+|disk_used	|double	|[{'dimension_name': 'availability_zone', 'data_type': 'varchar'}, {'dimension_name': 'microservice_name', 'data_type': 'varchar'}, {'dimension_name': 'instance_name', 'data_type': 'varchar'}, {'dimension_name': 'os_version', 'data_type': 'varchar'}, {'dimension_name': 'cell', 'data_type': 'varchar'}, {'dimension_name': 'region', 'data_type': 'varchar'}, {'dimension_name': 'silo', 'data_type': 'varchar'}, {'dimension_name': 'instance_type', 'data_type': 'varchar'}]	|
+|file_descriptors_in_use	|double	|[{'dimension_name': 'availability_zone', 'data_type': 'varchar'}, {'dimension_name': 'microservice_name', 'data_type': 'varchar'}, {'dimension_name': 'instance_name', 'data_type': 'varchar'}, {'dimension_name': 'os_version', 'data_type': 'varchar'}, {'dimension_name': 'cell', 'data_type': 'varchar'}, {'dimension_name': 'region', 'data_type': 'varchar'}, {'dimension_name': 'silo', 'data_type': 'varchar'}, {'dimension_name': 'instance_type', 'data_type': 'varchar'}]	|
+|gc_pause	|double	|[{'dimension_name': 'availability_zone', 'data_type': 'varchar'}, {'dimension_name': 'microservice_name', 'data_type': 'varchar'}, {'dimension_name': 'instance_name', 'data_type': 'varchar'}, {'dimension_name': 'process_name', 'data_type': 'varchar'}, {'dimension_name': 'jdk_version', 'data_type': 'varchar'}, {'dimension_name': 'cell', 'data_type': 'varchar'}, {'dimension_name': 'region', 'data_type': 'varchar'}, {'dimension_name': 'silo', 'data_type': 'varchar'}]	|
+|gc_reclaimed	|double	|[{'dimension_name': 'availability_zone', 'data_type': 'varchar'}, {'dimension_name': 'microservice_name', 'data_type': 'varchar'}, {'dimension_name': 'instance_name', 'data_type': 'varchar'}, {'dimension_name': 'process_name', 'data_type': 'varchar'}, {'dimension_name': 'jdk_version', 'data_type': 'varchar'}, {'dimension_name': 'cell', 'data_type': 'varchar'}, {'dimension_name': 'region', 'data_type': 'varchar'}, {'dimension_name': 'silo', 'data_type': 'varchar'}]	|
+|latency_per_read	|double	|[{'dimension_name': 'availability_zone', 'data_type': 'varchar'}, {'dimension_name': 'microservice_name', 'data_type': 'varchar'}, {'dimension_name': 'instance_name', 'data_type': 'varchar'}, {'dimension_name': 'os_version', 'data_type': 'varchar'}, {'dimension_name': 'cell', 'data_type': 'varchar'}, {'dimension_name': 'region', 'data_type': 'varchar'}, {'dimension_name': 'silo', 'data_type': 'varchar'}, {'dimension_name': 'instance_type', 'data_type': 'varchar'}]	|
+|latency_per_write	|double	|[{'dimension_name': 'availability_zone', 'data_type': 'varchar'}, {'dimension_name': 'microservice_name', 'data_type': 'varchar'}, {'dimension_name': 'instance_name', 'data_type': 'varchar'}, {'dimension_name': 'os_version', 'data_type': 'varchar'}, {'dimension_name': 'cell', 'data_type': 'varchar'}, {'dimension_name': 'region', 'data_type': 'varchar'}, {'dimension_name': 'silo', 'data_type': 'varchar'}, {'dimension_name': 'instance_type', 'data_type': 'varchar'}]	|
+|memory_cached	|double	|[{'dimension_name': 'availability_zone', 'data_type': 'varchar'}, {'dimension_name': 'microservice_name', 'data_type': 'varchar'}, {'dimension_name': 'instance_name', 'data_type': 'varchar'}, {'dimension_name': 'os_version', 'data_type': 'varchar'}, {'dimension_name': 'cell', 'data_type': 'varchar'}, {'dimension_name': 'region', 'data_type': 'varchar'}, {'dimension_name': 'silo', 'data_type': 'varchar'}, {'dimension_name': 'instance_type', 'data_type': 'varchar'}]	|
+|memory_free	|double	|[{'dimension_name': 'availability_zone', 'data_type': 'varchar'}, {'dimension_name': 'microservice_name', 'data_type': 'varchar'}, {'dimension_name': 'instance_name', 'data_type': 'varchar'}, {'dimension_name': 'process_name', 'data_type': 'varchar'}, {'dimension_name': 'os_version', 'data_type': 'varchar'}, {'dimension_name': 'jdk_version', 'data_type': 'varchar'}, {'dimension_name': 'cell', 'data_type': 'varchar'}, {'dimension_name': 'region', 'data_type': 'varchar'}, {'dimension_name': 'silo', 'data_type': 'varchar'}, {'dimension_name': 'instance_type', 'data_type': 'varchar'}]	|
+|memory_used	|double	|[{'dimension_name': 'availability_zone', 'data_type': 'varchar'}, {'dimension_name': 'microservice_name', 'data_type': 'varchar'}, {'dimension_name': 'instance_name', 'data_type': 'varchar'}, {'dimension_name': 'os_version', 'data_type': 'varchar'}, {'dimension_name': 'cell', 'data_type': 'varchar'}, {'dimension_name': 'region', 'data_type': 'varchar'}, {'dimension_name': 'silo', 'data_type': 'varchar'}, {'dimension_name': 'instance_type', 'data_type': 'varchar'}]	|
+|network_bytes_in	|double	|[{'dimension_name': 'availability_zone', 'data_type': 'varchar'}, {'dimension_name': 'microservice_name', 'data_type': 'varchar'}, {'dimension_name': 'instance_name', 'data_type': 'varchar'}, {'dimension_name': 'os_version', 'data_type': 'varchar'}, {'dimension_name': 'cell', 'data_type': 'varchar'}, {'dimension_name': 'region', 'data_type': 'varchar'}, {'dimension_name': 'silo', 'data_type': 'varchar'}, {'dimension_name': 'instance_type', 'data_type': 'varchar'}]	|
+|network_bytes_out	|double	|[{'dimension_name': 'availability_zone', 'data_type': 'varchar'}, {'dimension_name': 'microservice_name', 'data_type': 'varchar'}, {'dimension_name': 'instance_name', 'data_type': 'varchar'}, {'dimension_name': 'os_version', 'data_type': 'varchar'}, {'dimension_name': 'cell', 'data_type': 'varchar'}, {'dimension_name': 'region', 'data_type': 'varchar'}, {'dimension_name': 'silo', 'data_type': 'varchar'}, {'dimension_name': 'instance_type', 'data_type': 'varchar'}]	|
+|task_completed	|bigint	|[{'dimension_name': 'availability_zone', 'data_type': 'varchar'}, {'dimension_name': 'microservice_name', 'data_type': 'varchar'}, {'dimension_name': 'instance_name', 'data_type': 'varchar'}, {'dimension_name': 'process_name', 'data_type': 'varchar'}, {'dimension_name': 'jdk_version', 'data_type': 'varchar'}, {'dimension_name': 'cell', 'data_type': 'varchar'}, {'dimension_name': 'region', 'data_type': 'varchar'}, {'dimension_name': 'silo', 'data_type': 'varchar'}]	|
+|task_end_state	|varchar	|[{'dimension_name': 'availability_zone', 'data_type': 'varchar'}, {'dimension_name': 'microservice_name', 'data_type': 'varchar'}, {'dimension_name': 'instance_name', 'data_type': 'varchar'}, {'dimension_name': 'process_name', 'data_type': 'varchar'}, {'dimension_name': 'jdk_version', 'data_type': 'varchar'}, {'dimension_name': 'cell', 'data_type': 'varchar'}, {'dimension_name': 'region', 'data_type': 'varchar'}, {'dimension_name': 'silo', 'data_type': 'varchar'}]	|
+
+
+### Table schema with multi-measure record
+
+Below is the table schema when metrics are stored using multi-measure records.
+
+```
+DESCRIBE db.table
+```
+
+|**Column**	|**Type**	|**Timestream attribute type**	|
+|---	|---	|---	|
+|availability_zone	|varchar	|DIMENSION	|
+|microservice_name	|varchar	|DIMENSION	|
+|instance_name	|varchar	|DIMENSION	|
+|process_name	|varchar	|DIMENSION	|
+|os_version	|varchar	|DIMENSION	|
+|jdk_version	|varchar	|DIMENSION	|
+|cell	|varchar	|DIMENSION	|
+|region	|varchar	|DIMENSION	|
+|silo	|varchar	|DIMENSION	|
+|instance_type	|varchar	|DIMENSION	|
+|measure_name	|varchar	|MEASURE_NAME	|
+|time	|timestamp	|TIMESTAMP	|
+|memory_free	|double	|MULTI	|
+|cpu_steal	|double	|MULTI	|
+|cpu_iowait	|double	|MULTI	|
+|cpu_user	|double	|MULTI	|
+|memory_cached	|double	|MULTI	|
+|disk_io_reads	|double	|MULTI	|
+|cpu_hi	|double	|MULTI	|
+|latency_per_read	|double	|MULTI	|
+|network_bytes_out	|double	|MULTI	|
+|cpu_idle	|double	|MULTI	|
+|disk_free	|double	|MULTI	|
+|memory_used	|double	|MULTI	|
+|cpu_system	|double	|MULTI	|
+|file_descriptors_in_use	|double	|MULTI	|
+|disk_used	|double	|MULTI	|
+|cpu_nice	|double	|MULTI	|
+|disk_io_writes	|double	|MULTI	|
+|cpu_si	|double	|MULTI	|
+|latency_per_write	|double	|MULTI	|
+|network_bytes_in	|double	|MULTI	|
+|task_end_state	|varchar	|MULTI	|
+|gc_pause	|double	|MULTI	|
+|task_completed	|bigint	|MULTI	|
+|gc_reclaimed	|double	|MULTI	|
+
+Below is the measure schema, i.e., the mapping of the measures to dimensions.
+
+```
+SHOW MEASURES FROM db.table
+```
+
+|**measure_name**	|**data_type**	|**dimensions**	|
+|---	|---	|---	|
+|events	|multi	|[{'dimension_name': 'availability_zone', 'data_type': 'varchar'}, {'dimension_name': 'microservice_name', 'data_type': 'varchar'}, {'dimension_name': 'instance_name', 'data_type': 'varchar'}, {'dimension_name': 'process_name', 'data_type': 'varchar'}, {'dimension_name': 'jdk_version', 'data_type': 'varchar'}, {'dimension_name': 'cell', 'data_type': 'varchar'}, {'dimension_name': 'region', 'data_type': 'varchar'}, {'dimension_name': 'silo', 'data_type': 'varchar'}]	|
+|metrics	|multi	|[{'dimension_name': 'availability_zone', 'data_type': 'varchar'}, {'dimension_name': 'microservice_name', 'data_type': 'varchar'}, {'dimension_name': 'instance_name', 'data_type': 'varchar'}, {'dimension_name': 'os_version', 'data_type': 'varchar'}, {'dimension_name': 'cell', 'data_type': 'varchar'}, {'dimension_name': 'region', 'data_type': 'varchar'}, {'dimension_name': 'silo', 'data_type': 'varchar'}, {'dimension_name': 'instance_type', 'data_type': 'varchar'}]	|
+
+
 ### Example ingestion command line
 
 Below are example command lines to start ingestion for the first two rows of the table above.
 
 **Small scale**
 ```
-python3 devops_ingestion_driver.py -d perf_scale -t test -e us-east-1 -c 30 -p 20 --host-scale 100 --interval-millis 60000
+python3 devops_ingestion_driver.py -d perf_scale -t test -r us-east-1 -c 30 -p 20 --host-scale 100 --interval-millis 60000
 ```
 **Medium scale**
 
 ```
-python3 devops_ingestion_driver.py -d perf_scale -t test -e us-east-1 -c 50 -p 50 --host-scale 2000 --interval-millis 300000
+python3 devops_ingestion_driver.py -d perf_scale -t test -r us-east-1 -c 50 -p 50 --host-scale 2000 --interval-millis 300000
 ```
 
 This command will launch 50 processes, which in turn will launch 50 threads to generate the ingestion load. Each thread synchronously ingests data using the Python SDK of Timestream. The ingester continues to run continuously until a ``SIGINT`` signal is sent to the process. It prints summary statistics as it continues to ingest.
@@ -130,6 +286,22 @@ As the ingestion workload is scaling up, Timestream will automatically scale res
 ### Note
 
 If during ingestion, the driver prints a steady stream of messages of the ``Can't keep up ingestion to the desired inter-event interval ...``, it implies more parallelism is needed in the workload generator. This can be modified using the arguments ``-p`` and ``-c`` or launch multiple instances of the ingester (see below). Since Python multi-threading is still serialized through the global interpreter lock, ``-c`` higher than 50 does not result in increasing the effective parallelism. In such cases, it is recommended to increase the value of ``-p``. The number of processes that can be launch is dependent on the CPU and memory available on the EC2 instance. If the EC2 instance is already high in CPU and memory utilization, consider splitting up the ingester into multiple instances across multiple EC2 instances (see below).
+
+### Batching writes
+
+To improve the ingestion throughput, it is also recommended to batch writes up to the maximum batch size supported by Timestream. To help with that, there are two batching options supported. ``--batch-writes`` enables batching writes across multiple hosts, while ``--batch-size`` controls the number of records per batch (default: 100).
+
+```
+python3 devops_ingestion_driver.py -d perf_scale -t test -r us-east-1 -c 50 -p 50 --host-scale 2000 --interval-millis 300000 --batch-writes
+```
+
+### Ingestion using multi-measure records
+
+If you'd like to ingest using multi-measure records, then add the ``--multi`` option to the ingestion command.
+
+```
+python3 devops_ingestion_driver.py -d perf_scale -t test -r us-east-1 -c 50 -p 50 --host-scale 2000 --interval-millis 300000 --batch-writes --multi
+```
 
 ### Multiple instances of the ingester
 
@@ -143,13 +315,13 @@ For instance, if the goal for ingestion is ``--host-scale 4000``, and to partiti
 **Host 1**
 
 ```
-python3 devops_ingestion_driver.py -d perf_scale -t test -e us-east-1 -c 50 -p 50 --host-scale 2000 --interval-millis 120000 --instance-name-seed 12345
+python3 devops_ingestion_driver.py -d perf_scale -t test -r us-east-1 -c 50 -p 50 --host-scale 2000 --interval-millis 120000 --instance-name-seed 12345
 ```
 
 **Host 2**
 
 ```
-python3 devops_ingestion_driver.py -d perf_scale -t test -e us-east-1 -c 50 -p 50 --host-scale 2000 --interval-millis 120000 --instance-name-seed 56789
+python3 devops_ingestion_driver.py -d perf_scale -t test -r us-east-1 -c 50 -p 50 --host-scale 2000 --interval-millis 120000 --instance-name-seed 56789
 ```
 
 Note that only difference in the command lines on the two hosts is the ``--instance-name-seed`` option. The data generator uses the seed to generate a psuedo-random string in the instance name. Different seeds allow different sets of instance names to be created, which essentially allows generating metrics for two sets of hosts. In this case, it creates two sets of hosts, thus resulting in the overall equivalent host scale of 4,000.
@@ -169,7 +341,7 @@ Note that the example queries defined in ``devops_query_driver.py`` use up to 3 
 Following is an example command line to execute 10 concurrent sessions.
 
 ```
-python3 devops_query_driver.py -d perf_scale -t test -e us-east-1 --config config.ini -c 5 -p 2 -l ~/experiment_log/r1 --think-time-milliseconds 300000 --randomized-think-time
+python3 devops_query_driver.py -d perf_scale -t test -r us-east-1 --config config.ini -c 5 -p 2 -l ~/experiment_log/r1 --think-time-milliseconds 300000 --randomized-think-time
 ```
 
 The above command line executes six queries, defined in the file ``devops_query_driver.py`` that correspond to *alerting*, *dashboards*, and *analysis* queries.
@@ -185,16 +357,32 @@ Query type, Total Count, Successful Count, Avg. latency (in secs), Std dev laten
 do-q1, 2956, 2956, 1.55, 0.6, 1.493, 1.94, 2.544, 1.502
 ```
 
+### Queries using multi-measure records
+
+The default command line assumes the data in the scalar model. To execute queries for the data in the Multi model, add ``--multi`` parameter to the command line. For instance:
+
+```
+python3 devops_query_driver.py -d perf_scale -t test -r us-east-1 --config config.ini -c 5 -p 2 -l ~/experiment_log/r1 --think-time-milliseconds 300000 --randomized-think-time --multi
+```
+
 ### Note
 
 Timestream automatically scales resources allocated to queries. Hence, during load spikes, the requests may encounter occasional throttling exceptions with the message ``Request rate limit exceeded``. It is recommended to retry the requests with a back-off. If requests continue to be throttled, consider reaching out through usual support channels.
+
+### Summarize results from query workload
+
+Each executer of the query workload creates a summary file in the output log directory specified when executing the ``devops_query_driver.py``. The overall run summary aggregating the stats from these multiple executers can be generated using the following command:
+
+```
+python3 summarize_results.py -d ~/experiment_log/r1 -o ~/experiment_log/r1/summarized.csv
+```
 
 ## Cleanup
 
 Once the performance experiments are completed, it is important to clean up the resources. A simple utility cleans up Timestream resources.
 
 ```
-python3 devops_cleanup_resources.py -d perf_scale -t test -e us-east-1
+python3 devops_cleanup_resources.py -d perf_scale -t test -r us-east-1
 ```
 
 Follow the [instructions](https://aws.amazon.com/premiumsupport/knowledge-center/delete-terminate-ec2/) to delete the EC2 instances to also avoid billing for those instance.

--- a/tools/perf-scale-workload/devops_cleanup_resources.py
+++ b/tools/perf-scale-workload/devops_cleanup_resources.py
@@ -13,13 +13,14 @@ if __name__ == "__main__":
 
     parser.add_argument('--database-name', '-d', dest="databaseName", action = "store", required = True, help = "The database name for the workload.")
     parser.add_argument('--table-name', '-t', dest="tableName", action = "store", required = True, help = "The table name for the workload.")
-    parser.add_argument('--endpoint', '-e', action = "store", required = True, help="Specify the region where the Timestream database is located.")
+    parser.add_argument('--region', '-r', action = "store", required = True, help="Specify the region where the Timestream database is located.")
+    parser.add_argument('--endpoint', '-e', action = "store", default = None, help="Specify the endpoint where the Timestream database is located.")
     parser.add_argument('--profile', action = "store", type = str, default= None, help = "The AWS profile to use.")
 
     args = parser.parse_args()
     print(args)
 
-    client = tswrite.createWriteClient(args.endpoint, args.profile)
+    client = tswrite.createWriteClient(region=args.region, profile=args.profile, endpoint=args.endpoint)
     try:
         result = tswrite.deleteTable(client, args.databaseName, args.tableName)
         print("Delete table status: ", result['ResponseMetadata']['HTTPStatusCode'])

--- a/tools/perf-scale-workload/devops_ingestion_driver.py
+++ b/tools/perf-scale-workload/devops_ingestion_driver.py
@@ -15,7 +15,7 @@ import botocore.exceptions
 
 def createDatabaseAndTable(args):
     ##
-    client = tswrite.createWriteClient(args.endpoint, args.profile)
+    client = tswrite.createWriteClient(region=args.region, profile=args.profile, endpoint=args.endpoint)
     try:
         result = tswrite.createDatabase(client, args.databaseName)
         print(result)
@@ -51,13 +51,19 @@ if __name__ == "__main__":
 
     parser.add_argument('--database-name', '-d', dest="databaseName", action = "store", required = True, help = "The database name for the workload.")
     parser.add_argument('--table-name', '-t', dest="tableName", action = "store", required = True, help = "The table name for the workload.")
-    parser.add_argument('--endpoint', '-e', action = "store", required = True, help="Specify the region where the Timestream database is located.")
+    parser.add_argument('--region', '-r', action = "store", required = True, help="Specify the region where the Timestream database is located.")
+    parser.add_argument('--endpoint', '-e', action = "store", default = None, help="Specify the endpoint where the Timestream database is located.")
     parser.add_argument('--memory-store-retention-hours', dest = "memoryStoreRetentionHours", action = "store", type = int, default = 2, help = "Memory store retention period of the table (in hours) [Default 2 hours].")
     parser.add_argument('--magnetic-store-retention-days', dest = "magneticStoreRetentionDays", action = "store", type = int, default = 365, help = "Magnetic store retention period of the table (in days) [Default 365 days].")
     parser.add_argument('--concurrency', '-c', action = "store", type = int, default = 1, help = "Number of concurrent threads to use (default: 1)")
     parser.add_argument('--processes', '-p', action = "store", type = int, default = 1, help = "Number of concurrent processes to use (default: 1)")
     parser.add_argument('--host-scale', dest = "hostScale", action = "store", type = int, default = 100, help = "The scale factor that determines the number of hosts emitting events and metrics. (default: 100)")
     parser.add_argument('--interval-millis', dest = "intervalMillis", action = "store", type = int, default = 5000, help = "Interval of time between events. (default: 5000)")
+    parser.add_argument('--batch-writes', dest = "batchWrites", action = "store_true", help = "Enable batching of write records.")
+    parser.add_argument('--batch-size', dest = "batchSize", type = int, default = 100, action = "store", help = "Specify the size of the batch of records when batching is enabled (default: 100).")
+    parser.add_argument('--multi', dest = "wide", action = "store_true", help = "Enable ingestion in the wide format.")
+    parser.add_argument('--add-req-id', dest = "addReqId", action = "store_true", help = "Enable adding a unique request id with every batch of data sent from a host at a given time.")
+    parser.add_argument('--req-id-dim', dest = "addReqIdAsDim", action = "store_true", help = "Add the request id as a dimension to the data point. Default is to add as measure value")
     parser.add_argument('--profile', action = "store", type = str, default= None, help = "The AWS profile to use.")
     parser.add_argument('--instance-name-seed', dest="instanceNameSeed", action = "store", type = int, default = 12345, help = "Seed to use for generating instance_name dimension values")
     parser.add_argument('--print-model-summary', dest = "modelSummary", action = "store_true", help = "Only print the data model summary")
@@ -65,9 +71,13 @@ if __name__ == "__main__":
     args = parser.parse_args()
     print(args)
 
-    dimensionsMetrics, dimensionsEvents = model.generateDimensions(args.hostScale)
+    if args.batchWrites and (args.batchSize > 100 or args.batchSize < 1):
+        print("Invalid value for --batch-size. Value should be between 1 and 100. Found: " + args.batchSize)
+        exit(1)
+
+    dimensionsMetrics, dimensionsEvents = model.generateDimensions(args.hostScale, args.instanceNameSeed)
     intervalSecs = int(args.intervalMillis / 1000)
-    model.printModelSummary(dimensionsMetrics, dimensionsEvents, intervalSecs, intervalSecs)
+    model.printModelSummary(dimensionsMetrics, dimensionsEvents, intervalSecs, intervalSecs, args.wide)
 
     if args.modelSummary:
         exit(0)

--- a/tools/perf-scale-workload/devops_query_driver.py
+++ b/tools/perf-scale-workload/devops_query_driver.py
@@ -45,6 +45,27 @@ ORDER BY p99_value DESC
 """
 
 ##
+## Variant of Q1 when data is emitted in the MULTI model.
+##
+q1StrMulti = """
+SELECT region, cell, silo, availability_zone, microservice_name,
+    BIN(time, 1m) AS time_bin,
+    COUNT(DISTINCT instance_name) AS num_hosts,
+    ROUND(AVG({4}), 2) AS avg_value,
+    ROUND(APPROX_PERCENTILE({4}, 0.9), 2) AS p90_value,
+    ROUND(APPROX_PERCENTILE({4}, 0.95), 2) AS p95_value,
+    ROUND(APPROX_PERCENTILE({4}, 0.99), 2) AS p99_value
+FROM {0}.{1}
+WHERE time BETWEEN {2} AND {3}
+    AND measure_name = 'metrics'
+    AND region = '{5}' AND cell = '{6}'
+    AND silo = '{7}' AND availability_zone = '{8}'
+    AND microservice_name = '{9}'
+GROUP BY region, cell, silo, availability_zone, microservice_name, BIN(time, 1m)
+ORDER BY p99_value DESC
+"""
+
+##
 ## This query emulates an alerting use-case where the goal is to obtain the aggregate values
 ## of multiple metrics, specifically cpu_user and cpu_system, for the specified time period
 ## for a given region, cell, silo, availability_zone, microservice_name, instance_type, and
@@ -60,6 +81,23 @@ WHERE time BETWEEN {2} AND {3}
     AND measure_name IN (
         'cpu_user', 'cpu_system'
     )
+    AND region = '{4}' AND cell = '{5}' AND silo = '{6}'
+    AND availability_zone = '{7}' AND microservice_name = '{8}'
+    AND instance_type = '{9}' AND os_version = '{10}'
+GROUP BY BIN(time, 1m)
+ORDER BY time_bin desc
+"""
+
+##
+## Variant of Q2 when data is emitted in the MULTI model
+##
+q2StrMulti = """
+SELECT BIN(time, 1m) AS time_bin,
+    AVG(cpu_user) AS avg_cpu_user,
+    AVG(cpu_system) AS avg_cpu_system
+FROM {0}.{1}
+WHERE time BETWEEN {2} AND {3}
+    AND measure_name = 'metrics'
     AND region = '{4}' AND cell = '{5}' AND silo = '{6}'
     AND availability_zone = '{7}' AND microservice_name = '{8}'
     AND instance_type = '{9}' AND os_version = '{10}'
@@ -100,6 +138,36 @@ ORDER BY i.instance_avg_metric DESC
 """
 
 ##
+## Variant of Q3 when data is emitted in the MULTI model
+##
+q3StrMulti = """
+WITH microservice_cell_avg AS (
+    SELECT cell, microservice_name,
+        AVG({5}) AS microservice_avg_metric
+    FROM {0}.{1}
+    WHERE time BETWEEN {2} AND {3}
+        AND region = '{4}'
+        AND measure_name = 'metrics'
+        AND microservice_name = '{6}'
+    GROUP BY cell, microservice_name
+), instance_avg AS (
+    SELECT cell, microservice_name, instance_name,
+        AVG({5}) AS instance_avg_metric
+    FROM {0}.{1}
+    WHERE time BETWEEN {2} AND {3}
+        AND region = '{4}'
+        AND measure_name = 'metrics'
+        AND microservice_name = '{6}'
+    GROUP BY instance_name, cell, microservice_name
+)
+SELECT i.*, m.microservice_avg_metric
+FROM microservice_cell_avg m INNER JOIN instance_avg i
+    ON i.cell = m.cell AND i.microservice_name = m.microservice_name
+WHERE i.instance_avg_metric > (1 + {7}) * m.microservice_avg_metric
+ORDER BY i.instance_avg_metric DESC
+"""
+
+##
 ## This query emulates populating a dashboard with the hourly distribution of different resource
 ## utilization metrics of the specified microservice_name across differen regions, cells, and
 ## silos for the past several hours.
@@ -108,7 +176,7 @@ q4Str = """
 SELECT region, silo, cell, microservice_name, BIN(time, 1h) AS hour,
     COUNT(CASE WHEN measure_name = 'cpu_user' THEN measure_value::double ELSE NULL END) AS num_cpu_user_samples,
     ROUND(AVG(CASE WHEN measure_name = 'cpu_user' THEN measure_value::double ELSE NULL END), 2) AS avg_cpu_user,
-    ROUND(MAX(CASE WHEN measure_name = 'cpu_user' THEN measure_value::double ELSE NULL END)) AS max_cpu_user,
+    ROUND(MAX(CASE WHEN measure_name = 'cpu_user' THEN measure_value::double ELSE NULL END), 2) AS max_cpu_user,
     COUNT(CASE WHEN measure_name = 'memory_used' THEN measure_value::double ELSE NULL END) AS num_memory_used_samples,
     ROUND(AVG(CASE WHEN measure_name = 'memory_used' THEN measure_value::double ELSE NULL END), 2) AS avg_memory_used,
     ROUND(MAX(CASE WHEN measure_name = 'memory_used' THEN measure_value::double ELSE NULL END), 2) AS max_memory_used
@@ -117,6 +185,25 @@ WHERE time BETWEEN {2} AND {3}
     AND measure_name IN (
         'cpu_user', 'memory_used'
     )
+    AND microservice_name = '{4}'
+GROUP BY silo, cell, region, microservice_name, BIN(time, 1h)
+ORDER BY region, silo, cell, microservice_name, hour DESC
+"""
+
+##
+## Variant of Q4 when data is emitted in the MULTI model
+##
+q4StrMulti = """
+SELECT region, silo, cell, microservice_name, BIN(time, 1h) AS hour,
+    COUNT(cpu_user) AS num_cpu_user_samples,
+    ROUND(AVG(cpu_user), 2) AS avg_cpu_user,
+    ROUND(MAX(cpu_user), 2) AS max_cpu_user,
+    COUNT(memory_used) AS num_memory_used_samples,
+    ROUND(AVG(memory_used), 2) AS avg_memory_used,
+    ROUND(MAX(memory_used), 2) AS max_memory_used
+FROM {0}.{1}
+WHERE time BETWEEN {2} AND {3}
+    AND measure_name = 'metrics'
     AND microservice_name = '{4}'
 GROUP BY silo, cell, region, microservice_name, BIN(time, 1h)
 ORDER BY region, silo, cell, microservice_name, hour DESC
@@ -174,6 +261,55 @@ GROUP BY t.instance_name, t.silo, t.microservice_name
 """
 
 ##
+## Variant of Q5 when data is emitted in the MULTI model
+##
+q5StrMulti = """
+WITH per_instance_memory_used AS (
+    SELECT silo, microservice_name, instance_name, BIN(time, 5m) AS time_bin,
+        MAX(memory_used) AS max_memory
+    FROM {0}.{1}
+    WHERE time BETWEEN {2} AND {3}
+        AND measure_name = 'metrics'
+        AND region = '{4}' AND cell = '{5}'
+        AND silo = '{6}' AND availability_zone = '{7}'
+    GROUP BY microservice_name, instance_name, BIN(time, 5m), silo
+), per_microservice_memory AS (
+    SELECT silo, microservice_name,
+        APPROX_PERCENTILE(max_memory, 0.95) AS p95_max_memory
+    FROM per_instance_memory_used
+    GROUP BY silo, microservice_name
+), per_silo_ranked AS (
+    SELECT silo, microservice_name,
+        DENSE_RANK() OVER (PARTITION BY silo ORDER BY p95_max_memory DESC) AS rank
+    FROM per_microservice_memory
+), instances_with_high_memory AS (
+    SELECT r.silo, r.microservice_name, m.instance_name,
+        APPROX_PERCENTILE(max_memory, 0.95) AS p95_max_memory
+    FROM per_silo_ranked r INNER JOIN per_instance_memory_used m
+        ON r.silo = m.silo AND r.microservice_name = m.microservice_name
+    WHERE r.rank = 1
+    GROUP BY m.instance_name, r.silo, r.microservice_name
+), ranked_instances AS (
+    SELECT silo, microservice_name, instance_name,
+        DENSE_RANK() OVER (PARTITION BY silo, microservice_name ORDER BY p95_max_memory DESC) AS rank
+    FROM instances_with_high_memory
+)
+SELECT t.silo, t.microservice_name, t.instance_name,
+    MIN(gc_pause) AS min_gc_pause,
+    ROUND(AVG(gc_pause), 2) AS avg_gc_pause,
+    ROUND(STDDEV(gc_pause), 2) AS stddev_gc_pause,
+    ROUND(APPROX_PERCENTILE(gc_pause, 0.5), 2) AS p50_gc_pause,
+    ROUND(APPROX_PERCENTILE(gc_pause, 0.9), 2) AS p90_gc_pause,
+    ROUND(APPROX_PERCENTILE(gc_pause, 0.99), 2) AS p99_gc_pause
+FROM ranked_instances r INNER JOIN {0}.{1} t ON
+    r.silo = t.silo AND
+    r.microservice_name = t.microservice_name AND r.instance_name = t.instance_name
+WHERE time BETWEEN {2} AND {3}
+    AND measure_name = 'events' AND rank = 1
+GROUP BY t.instance_name, t.silo, t.microservice_name
+"""
+
+##
 ## This query emulates an analysis scenario to find the hours of the day with highest CPU utilization
 ## across microservices for the specified region and cell.
 ##
@@ -203,6 +339,35 @@ WHERE rank <= 3
 ORDER BY microservice_name, day, rank ASC
 """
 
+##
+## Variant of Q5 when data is emitted in the MULTI model
+##
+q6StrMulti = """
+WITH per_instance_cpu_used AS (
+    SELECT microservice_name, instance_name, BIN(time, 15m) AS time_bin,
+        AVG(cpu_user) AS avg_cpu
+    FROM {0}.{1}
+    WHERE time BETWEEN {2} AND {3}
+        AND measure_name = 'metrics'
+        AND region = '{4}'
+        AND cell = '{5}'
+    GROUP BY instance_name, microservice_name, BIN(time, 15m)
+), per_microservice_cpu AS (
+    SELECT microservice_name, HOUR(time_bin) AS hour, BIN(time_bin, 24h) AS day,
+        APPROX_PERCENTILE(avg_cpu, 0.95) AS p95_avg_cpu
+    FROM per_instance_cpu_used
+    GROUP BY HOUR(time_bin), BIN(time_bin, 24h), microservice_name
+), per_microservice_ranked AS (
+    SELECT microservice_name, day, hour, p95_avg_cpu,
+        DENSE_RANK() OVER (PARTITION BY microservice_name, day ORDER BY p95_avg_cpu DESC) AS rank
+    FROM per_microservice_cpu
+)
+SELECT microservice_name, day, hour AS hour, p95_avg_cpu
+FROM per_microservice_ranked
+WHERE rank <= 3
+ORDER BY microservice_name, day, rank ASC
+"""
+
 q1 = "do-q1"
 q2 = "do-q2"
 q3 = "do-q3"
@@ -211,22 +376,37 @@ q5 = "do-q5"
 q6 = "do-q6"
 
 ### Create the query instances based on the specified parameters.
-def createQueryInstances(params, endTime = "now()"):
-
-    queries = {
-        ## Alerting query analyzing an hour of data.
-        q1 : Query(q1Str, tsb_query.QueryParams(1000, (params.dbname, params.tablename, "{} - 1h".format(endTime), "{}".format(endTime), "memory_used", params.region, params.cell, params.silo, params.az, params.microservicename))),
-        ## Alerting query analyzing an hour of data.
-        q2 : Query(q2Str, tsb_query.QueryParams(1000, (params.dbname, params.tablename, "{} - 1h".format(endTime), "{}".format(endTime), params.region, params.cell, params.silo, params.az, params.microservicename, params.instancetype, params.osversion))),
-        ## Populating a dashboard analyzing an hour of data.
-        q3 : Query(q3Str, tsb_query.QueryParams(50, (params.dbname, params.tablename, "{} - 1h".format(endTime), "{}".format(endTime), params.region, "disk_used", params.microservicename, 0.2))),
-        ## Populating a dashboard analyzing three hours of data.
-        q4 : Query(q4Str, tsb_query.QueryParams(50, (params.dbname, params.tablename, "{} - 3h".format(endTime), "{}".format(endTime), params.microservicename))),
-        ## Analysis query processing 1 day of data.
-        q5 : Query(q5Str, tsb_query.QueryParams(20, (params.dbname, params.tablename, "{} - 1d".format(endTime), "{}".format(endTime), params.region, params.cell, params.silo, params.az))),
-        ## Analysis query processing 3 days of data.
-        q6 : Query(q6Str, tsb_query.QueryParams(20, (params.dbname, params.tablename, "{} - 3d".format(endTime), "{}".format(endTime), params.region, params.cell)))
-    }
+def createQueryInstances(params, endTime = "now()", wide = False):
+    if wide:
+        queries = {
+            ## Alerting query analyzing an hour of data.
+            q1 : Query(q1StrMulti, tsb_query.QueryParams(1000, (params.dbname, params.tablename, "{} - 1h".format(endTime), "{}".format(endTime), "memory_used", params.region, params.cell, params.silo, params.az, params.microservicename))),
+            ## Alerting query analyzing an hour of data.
+            q2 : Query(q2StrMulti, tsb_query.QueryParams(1000, (params.dbname, params.tablename, "{} - 1h".format(endTime), "{}".format(endTime), params.region, params.cell, params.silo, params.az, params.microservicename, params.instancetype, params.osversion))),
+            ## Populating a dashboard analyzing an hour of data.
+            q3 : Query(q3StrMulti, tsb_query.QueryParams(50, (params.dbname, params.tablename, "{} - 1h".format(endTime), "{}".format(endTime), params.region, "disk_used", params.microservicename, 0.2))),
+            ## Populating a dashboard analyzing three hours of data.
+            q4 : Query(q4StrMulti, tsb_query.QueryParams(50, (params.dbname, params.tablename, "{} - 3h".format(endTime), "{}".format(endTime), params.microservicename))),
+            ## Analysis query processing 1 day of data.
+            q5 : Query(q5StrMulti, tsb_query.QueryParams(20, (params.dbname, params.tablename, "{} - 1d".format(endTime), "{}".format(endTime), params.region, params.cell, params.silo, params.az))),
+            ## Analysis query processing 3 days of data.
+            q6 : Query(q6StrMulti, tsb_query.QueryParams(20, (params.dbname, params.tablename, "{} - 3d".format(endTime), "{}".format(endTime), params.region, params.cell)))
+        }
+    else:
+        queries = {
+            ## Alerting query analyzing an hour of data.
+            q1 : Query(q1Str, tsb_query.QueryParams(1000, (params.dbname, params.tablename, "{} - 1h".format(endTime), "{}".format(endTime), "memory_used", params.region, params.cell, params.silo, params.az, params.microservicename))),
+            ## Alerting query analyzing an hour of data.
+            q2 : Query(q2Str, tsb_query.QueryParams(1000, (params.dbname, params.tablename, "{} - 1h".format(endTime), "{}".format(endTime), params.region, params.cell, params.silo, params.az, params.microservicename, params.instancetype, params.osversion))),
+            ## Populating a dashboard analyzing an hour of data.
+            q3 : Query(q3Str, tsb_query.QueryParams(50, (params.dbname, params.tablename, "{} - 1h".format(endTime), "{}".format(endTime), params.region, "disk_used", params.microservicename, 0.2))),
+            ## Populating a dashboard analyzing three hours of data.
+            q4 : Query(q4Str, tsb_query.QueryParams(50, (params.dbname, params.tablename, "{} - 3h".format(endTime), "{}".format(endTime), params.microservicename))),
+            ## Analysis query processing 1 day of data.
+            q5 : Query(q5Str, tsb_query.QueryParams(20, (params.dbname, params.tablename, "{} - 1d".format(endTime), "{}".format(endTime), params.region, params.cell, params.silo, params.az))),
+            ## Analysis query processing 3 days of data.
+            q6 : Query(q6Str, tsb_query.QueryParams(20, (params.dbname, params.tablename, "{} - 3d".format(endTime), "{}".format(endTime), params.region, params.cell)))
+        }
 
     return queries
 
@@ -236,16 +416,18 @@ if __name__ == "__main__":
 
     parser.add_argument('--database-name', '-d', dest="databaseName", action = "store", required = True, help = "The database name for the workload.")
     parser.add_argument('--table-name', '-t', dest="tableName", action = "store", required = True, help = "The table name for the workload.")
-    parser.add_argument('--endpoint', '-e', action = "store", required = True, help="Specify the region where the Timestream database is located.")
+    parser.add_argument('--region', '-r', action = "store", required = True, help="Specify the region where the Timestream database is located.")
+    parser.add_argument('--endpoint', '-e', action = "store", default = None, help="Specify the endpoint where the Timestream database is located.")
     parser.add_argument('--config', action = "store", type = str, required = True, help = "A configuration file defining properties of the workload")
     parser.add_argument('--concurrency', '-c', action = "store", type = int, default = 1, help = "Number of concurrent threads to use (default: 1)")
     parser.add_argument('--processes', '-p', action = "store", type = int, default = 1, help = "Number of concurrent processes to use (default: 1)")
     parser.add_argument('--log-dir', '-l', dest="logDir", action = "store", default = str(os.path.join(Path.home(), 'timestream_perf')), help = "The directory to log experiment results (default: ~/timestream_perf)")
-    parser.add_argument('--run-prefix', '-r', dest = "runPrefix", action = "store", default = None, help = "Identifier for the run.")
+    parser.add_argument('--run-prefix', dest = "runPrefix", action = "store", default = None, help = "Identifier for the run.")
     parser.add_argument('--query-end-time', dest = "queryEndTime", action = "store", default = "now()", help = "The interval end time for the query time predicates (default: 'now()')")
     parser.add_argument('--repetitions', action = "store", type = int, default = 0, help = "Whether to override the repetitions (default: 0)")
+    parser.add_argument('--multi', dest = "wide", action = "store_true", help = "Enable queries in the wide format.")
     parser.add_argument('--profile', action = "store", type = str, default= None, help = "The AWS profile to use.")
-    parser.add_argument('--think-time-milliseconds', dest = "thinkTimeMillis", action = "store", type = int, default = 30000, help = "Think time (in ms) between queries (default: 0)")
+    parser.add_argument('--think-time-milliseconds', dest = "thinkTimeMillis", action = "store", type = int, default = 30000, help = "Think time (in ms) between queries (default: 30000)")
     parser.add_argument('--randomized-think-time', dest = "randomizedThink", action = "store_true", help = "Use a randomized think time")
     parser.add_argument('--fixed-params', dest = "fixedParams", action = "store_true", help = "Whether to use fixed parameters for queries or get the query parameters dynamically from database.")
 

--- a/tools/perf-scale-workload/summarize_results.py
+++ b/tools/perf-scale-workload/summarize_results.py
@@ -1,0 +1,82 @@
+##################################################
+## A helper to summarize the statistics from a  ##
+## concurrent run for the query workload. ########
+##################################################
+
+import argparse
+import pprint
+import glob
+import os
+import csv
+import numpy as np
+
+if __name__ == "__main__":
+
+    parser = argparse.ArgumentParser(prog = 'Summarize query latency', description='Summarize the runs from the multiple files emitted from a concurrent run.')
+
+    parser.add_argument('--directory', '-d', dest="directory", action = "store", required = True, help = "The directory which has the runs for the experiment being summarized.")
+    parser.add_argument('--pattern', '-p', dest="pattern", action = "store", default = "*.csv", help = "Pattern to search for in the files.")
+    parser.add_argument('--output-file', '-o', dest="outputFile", action = "store", required = True, help = "The output file to store summarized output.")
+
+    args = parser.parse_args()
+    print(args)
+
+    if not os.path.isdir(args.directory):
+        print("Invalid path: ", args.directory)
+        exit()
+
+    headerString = None
+    perQueryStats = dict()
+    perQueryAggregatedStats = dict()
+    try:
+        ## Convert to absolute path. Add a trailing separator if it doesn't exist
+        absoluteDirPath = os.path.join(os.path.abspath(args.directory), '')
+        fileCount = 0
+        ## Recursively read in add the files that contain the per thread summary based on the specified file pattern.
+        for filename in glob.iglob(absoluteDirPath + os.path.join('**', args.pattern), recursive=True):
+            with open(filename) as csvfile:
+                lineReader = csv.reader(csvfile)
+                header = True
+                ## Here we assume that these files are comma-separated summary of the individual thread's execution stats.
+                ## Each file has a header and number of rows of summarized stats.
+                ## Each row has the first column as the name of the query, and subsequent columns as the stats.
+                ## Example file with header and one row.
+                ## Query type, Total Count, Successful Count, Avg. latency (in secs), Std dev latency (in secs), Median, 90th perc (in secs), 99th Perc (in secs), Geo Mean (in secs)
+                ## do-q1,11586.5,11586.5,0.47,0.156,0.451,0.525,0.729,0.463
+                for row in lineReader:
+                    if header:
+                        ## We assume all files have the same header row. So save the row of one of the files.
+                        headerString = row
+                        header = False
+                        continue
+
+                    ## The first column is the name of the query. We find all the summarizes for this operation across all the files.
+                    if row[0] not in perQueryStats:
+                        perQueryStats[row[0]] = list()
+                    ## Store the stats second column onwards.
+                    perQueryStats[row[0]].append([float(x) for x in row[1:]])
+            fileCount += 1
+
+        for key in perQueryStats.keys():
+            value = perQueryStats[key]
+            ## For each column, compute the average across all the files.
+            perElementAvg = np.average(value, axis=0)
+            perQueryAggregatedStats[key] = ["{0}".format(round(x, 3)) for x in perElementAvg]
+
+        ## Write the summary in the aggregate file in the same format as the original files
+        ## First row is the header read from the files.
+        ## Second row onwards is the aggregated summary for each operation, averaged across all the files found in the specified path.
+        outputFile = os.path.join(args.directory, args.outputFile)
+        print("Processed {0} files. Summary written to: {1}".format(fileCount, outputFile))
+        with open(outputFile, 'w') as out:
+            writer = csv.writer(out)
+            writer.writerow(headerString)
+            for key in perQueryAggregatedStats.keys():
+                row = list()
+                row.append(key)
+                row.extend(perQueryAggregatedStats[key])
+                writer.writerow(row)
+
+    except Exception as e:
+        pprint.pprint(e)
+        raise e

--- a/tools/perf-scale-workload/timestreamwrite.py
+++ b/tools/perf-scale-workload/timestreamwrite.py
@@ -8,7 +8,7 @@ import pprint
 '''
 ## Create a timestream write client.
 '''
-def createWriteClient(region, profile = None, credStr = None):
+def createWriteClient(region, profile = None, credStr = None, endpoint = None):
     if profile == None and credStr == None:
         print("Using credentials from the environment")
 
@@ -16,12 +16,20 @@ def createWriteClient(region, profile = None, credStr = None):
     config = Config(read_timeout = 335, connect_timeout = 20, retries = {'max_attempts': 10})
     if profile != None:
         session = boto3.Session(profile_name = profile)
-        client = session.client(service_name = 'timestream-write',
-                            region_name = region, config = config)
+        if endpoint != None:
+            client = session.client(service_name = 'timestream-write', endpoint_url=endpoint,
+                region_name = region, config = config)
+        else:
+            client = session.client(service_name = 'timestream-write',
+                region_name = region, config = config)
     else:
         session = boto3.Session()
-        client = session.client(service_name = 'timestream-write',
-                            region_name = region, config = config)
+        if endpoint != None:
+            client = session.client(service_name = 'timestream-write', endpoint_url=endpoint,
+                region_name = region, config = config)
+        else:
+            client = session.client(service_name = 'timestream-write',
+                region_name = region, config = config)
     return client
 
 def describeTable(client, databaseName, tableName):
@@ -30,6 +38,9 @@ def describeTable(client, databaseName, tableName):
 def writeRecords(client, databaseName, tableName, commonAttributes, records):
     return client.write_records(DatabaseName = databaseName, TableName = tableName,
         CommonAttributes = (commonAttributes), Records = (records))
+
+def writeRecords(client, databaseName, tableName, records):
+    return client.write_records(DatabaseName = databaseName, TableName = tableName, Records = (records))
 
 def createDatabase(client, databaseName):
     return client.create_database(DatabaseName = databaseName)


### PR DESCRIPTION

*Issue #, if available:*

*Description of changes:*

By passing an extra --multi option to the ingestion and query scripts, the data is written using multi-measure records and the corresponding queries are also adopted to use the new multi-measure schema.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
