### PR TITLE
Update TimestreamSink.java

### DIFF
--- a/integrations/flink_connector/src/main/java/com/amazonaws/services/timestream/TimestreamSink.java
+++ b/integrations/flink_connector/src/main/java/com/amazonaws/services/timestream/TimestreamSink.java
@@ -106,7 +106,7 @@ public class TimestreamSink extends RichSinkFunction<TimestreamPoint> implements
 
                     LOG.warn("Discarding Malformed Record ->" + rejectedRecords.get(i).toString());
                     LOG.warn("Rejected Record Reason ->" + 	rejectedRecords.get(i).getReason());
-                    bufferedRecords.remove(rejectedRecords.get(i).getRecordIndex());
+                    bufferedRecords.remove(rejectedRecords.get(i).getRecordIndex().intValue());
 
                 }
             }   catch (Exception e) {


### PR DESCRIPTION
Fixed a bug that would cause RejectedRecords to never get removed from `bufferedRecords`.

*Issue #, if available:*

*Description of changes:*
Pass in an actual integer to `recordsToSend.remove` instead of an `Integer` object.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
