### PR TITLE
update Timestream Sink sample to use the sink published in Maven; update READMEs accordingly. See issue #110

### DIFF
--- a/integrations/flink_connector/README.md
+++ b/integrations/flink_connector/README.md
@@ -28,15 +28,9 @@ mvn -version
 
 ### 2. Setup Environment
 
-1. Create an Amazon Kinesis Data Stream with the name "TimestreamTestStream". You can use the below AWS CLI command:
+Create an Amazon Kinesis Data Stream with the name "TimestreamTestStream". You can use the below AWS CLI command:
 ```
 aws kinesis create-stream --stream-name TimestreamTestStream --shard-count 1
-```
-
-2. Install Timestream Sink, so it's available for other applications as Maven module:
-```shell
-cd flink-connector-timestream
-mvn clean compile && mvn install
 ```
 
 ### 3 (option A). Run Sample Flink Application locally

--- a/integrations/flink_connector/flink-connector-timestream/README.md
+++ b/integrations/flink_connector/flink-connector-timestream/README.md
@@ -19,23 +19,14 @@ This directory contains the sink code itself - a reusable component which you ca
 
 ## Using Timestream Sink in a new project
 
-### Install to local Maven repository
-
-First, you need to make Timestream Sink available for other Maven projects. ** Note: this is a necessary step if you want to use the sink in other projects as Maven module.**. Execute the following command in this directory to install the sink to local Maven repository:
+The sink is available [in the Maven repository](https://mvnrepository.com/artifact/software.amazon.timestream/flink-connector-timestream/0.1). Define the Maven dependency on the sink as follows:
 
 ```
-mvn install
-```
-
-### Define Maven dependency
-
-After the Sink is installed locally, you can use it as any other Maven module. Define the Maven dependency on the sink as follows:
-
-```
+<!-- https://mvnrepository.com/artifact/software.amazon.timestream/flink-connector-timestream -->
 <dependency>
-    <groupId>com.amazonaws.samples.connectors.timestream</groupId>
+    <groupId>software.amazon.timestream</groupId>
     <artifactId>flink-connector-timestream</artifactId>
-    <version>0.1-SNAPSHOT</version>
+    <version>0.1</version>
 </dependency>
 ```
 
@@ -140,6 +131,29 @@ Run tests:
 mvn test
 ```
 
+## Developing Timestream Sink
+
+Follow the steps below to use custom compiled sink version in your projects.
+
+### Install to local Maven repository
+
+First, you need to make your custom Timestream Sink available for other Maven projects. **Note: this is a necessary step if you want to use the sink in other projects as Maven module.** Execute the following command in this directory to install the sink to local Maven repository:
+
+```
+mvn install
+```
+
+### Define Maven dependency
+
+After the Sink is installed locally, you can use it as any other Maven module. Define the Maven dependency on the sink as follows:
+
+```
+<dependency>
+    <groupId>com.amazonaws.samples.connectors.timestream</groupId>
+    <artifactId>flink-connector-timestream</artifactId>
+    <version>0.1-SNAPSHOT</version>
+</dependency>
+```
 
 ## Troubleshooting
 

--- a/integrations/flink_connector/flink-connector-timestream/pom.xml
+++ b/integrations/flink_connector/flink-connector-timestream/pom.xml
@@ -25,7 +25,7 @@ under the License.
     <packaging>jar</packaging>
 
     <name>flink-connector-timestream</name>
-    <url>http://TODO.REPLACE.com/docs</url>
+    <url>https://github.com/awslabs/amazon-timestream-tools/tree/mainline/integrations/flink_connector/flink-connector-timestream</url>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/integrations/flink_connector/sample-kinesis-to-timestream-app/pom.xml
+++ b/integrations/flink_connector/sample-kinesis-to-timestream-app/pom.xml
@@ -25,7 +25,7 @@ under the License.
     <packaging>jar</packaging>
 
     <name>Sample Kinesis to Timestream Application</name>
-    <url>http://TODO.REPLACE.com/docs</url>
+    <url>https://github.com/awslabs/amazon-timestream-tools/tree/mainline/integrations/flink_connector/sample-kinesis-to-timestream-app</url>
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -114,9 +114,9 @@ under the License.
         </dependency>
         <!-- For writing to Timestream -->
         <dependency>
-            <groupId>com.amazonaws.samples.connectors.timestream</groupId>
+            <groupId>software.amazon.timestream</groupId>
             <artifactId>flink-connector-timestream</artifactId>
-            <version>0.1-SNAPSHOT</version>
+            <version>0.1</version>
         </dependency>
 
         <!-- sdk dependencies -->


### PR DESCRIPTION
*Issue #, if available:*

https://github.com/awslabs/amazon-timestream-tools/issues/110

*Description of changes:*

- updated sample to use the sink published to Maven 
- updated sink related README files

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
