### PR TITLE
fix: no retry ValidationException

### DIFF
--- a/integrations/flink_connector/flink-connector-timestream/src/main/java/com/amazonaws/samples/connectors/timestream/DefaultWriteRequestFailureHandler.java
+++ b/integrations/flink_connector/flink-connector-timestream/src/main/java/com/amazonaws/samples/connectors/timestream/DefaultWriteRequestFailureHandler.java
@@ -199,15 +199,15 @@ public class DefaultWriteRequestFailureHandler implements WriteRequestFailureHan
                              final Consumer<List<Record>> dropCompletionConsumer) {
         final Class<? extends Exception> exceptionClass = exception.getClass();
         LOG.debug("Sending WriteRecordsRequest failed. Starting handling exception: {}", exceptionClass.getName());
-        if (checkIsRetryableException(exception)) {
-            handleRetryableException(requestEntries, writeRecordsRequest, exception,
-                    retryOrSuccessCompletionConsumer, dropCompletionConsumer);
-        } else if (exceptionTypeToExceptionHandleMethod.containsKey(exceptionClass)) {
+        if (exceptionTypeToExceptionHandleMethod.containsKey(exceptionClass)) {
             LOG.debug("Found designated exception handler method.");
             exceptionTypeToExceptionHandleMethod
                     .get(exceptionClass)
                     .accept(requestEntries, writeRecordsRequest, exception,
                             retryOrSuccessCompletionConsumer, dropCompletionConsumer);
+        } else if (checkIsRetryableException(exception)) {
+            handleRetryableException(requestEntries, writeRecordsRequest, exception,
+                    retryOrSuccessCompletionConsumer, dropCompletionConsumer);
         } else {
             LOG.debug("No designated exception handler method found. Launching the default handler.");
             handleDefaultException(requestEntries, writeRecordsRequest, exception,


### PR DESCRIPTION
Signed-off-by: BobDu <i@bobdu.cc>

*Issue #, if available:*
related: #101 

*Description of changes:*
`ValidationException` is a can not retry. But the ValidationError http status code is `400` 
https://docs.aws.amazon.com/timestream/latest/developerguide/CommonErrors.html#:~:text=Status%20Code%3A%20400-,ValidationError,-The%20input%20fails

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
