### PR TITLE
Fixing groupId for flink-connector-timestream

### DIFF
--- a/integrations/flink_connector/sample-kinesis-to-timestream-app/pom.xml
+++ b/integrations/flink_connector/sample-kinesis-to-timestream-app/pom.xml
@@ -113,7 +113,7 @@ under the License.
         </dependency>
         <!-- For writing to Timestream -->
         <dependency>
-            <groupId>com.amazonaws.samples.connectors.timestream</groupId>
+            <groupId>software.amazon.timestream</groupId>
             <artifactId>flink-connector-timestream</artifactId>
             <version>0.3</version>
         </dependency>


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Fixing groupId for flink-connector-timestream as there is new version published to maven - https://mvnrepository.com/artifact/software.amazon.timestream/flink-connector-timestream/0.3


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
