### PR TITLE
AT-1456 upgrade flink/bom dependency to use latest versions

### DIFF
--- a/integrations/flink_connector/flink-connector-timestream/pom.xml
+++ b/integrations/flink_connector/flink-connector-timestream/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <modelVersion>4.0.0</modelVersion>
     <artifactId>flink-connector-timestream</artifactId>
     <groupId>com.amazonaws.samples.connectors.timestream</groupId>
-    <version>0.2-SNAPSHOT</version>
+    <version>0.3-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>flink-connector-timestream</name>
@@ -29,7 +29,7 @@ under the License.
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <flink.version>1.15.3</flink.version>
+        <flink.version>1.17.1</flink.version>
         <java.version>1.11</java.version>
         <jdk.version>11</jdk.version>
         <next.jdk.version>12</next.jdk.version>
@@ -42,7 +42,7 @@ under the License.
             <dependency>
                 <groupId>software.amazon.awssdk</groupId>
                 <artifactId>bom</artifactId>
-                <version>2.17.203</version>
+                <version>2.20.101</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -89,7 +89,7 @@ under the License.
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>aws-crt-client</artifactId>
-            <version>2.17.204-PREVIEW</version>
+            <version>2.20.101</version>
         </dependency>
 
         <!-- Test dependencies -->

--- a/integrations/flink_connector/flink-connector-timestream/src/test/java/com/amazonaws/samples/connectors/timestream/SinkInitContext.java
+++ b/integrations/flink_connector/flink-connector-timestream/src/test/java/com/amazonaws/samples/connectors/timestream/SinkInitContext.java
@@ -60,6 +60,11 @@ public class SinkInitContext implements InitContext {
         return 0;
     }
 
+    @Override
+    public int getAttemptNumber() {
+        return 1;
+    }
+
     /**
      * @return The metric group this writer belongs to.
      */


### PR DESCRIPTION
*IAT-1456* https://bitquill.atlassian.net/browse/AT-1456

*Description of changes:*
Updated pom file to use latest available flink version and other dependencied
Change tests to support latest interface versions

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
