### PR TITLE
GH #146 - Flink application could not reach Timestream after version upgrade #146 - Part II.

### DIFF
--- a/integrations/flink_connector/flink-connector-timestream/pom.xml
+++ b/integrations/flink_connector/flink-connector-timestream/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <modelVersion>4.0.0</modelVersion>
     <artifactId>flink-connector-timestream</artifactId>
     <groupId>com.amazonaws.samples.connectors.timestream</groupId>
-    <version>0.2-SNAPSHOT</version>
+    <version>0.3-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>flink-connector-timestream</name>
@@ -29,7 +29,7 @@ under the License.
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <flink.version>1.15.3</flink.version>
+        <flink.version>1.17.1</flink.version>
         <java.version>1.11</java.version>
         <jdk.version>11</jdk.version>
         <next.jdk.version>12</next.jdk.version>
@@ -42,7 +42,7 @@ under the License.
             <dependency>
                 <groupId>software.amazon.awssdk</groupId>
                 <artifactId>bom</artifactId>
-                <version>2.17.203</version>
+                <version>2.20.101</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -89,7 +89,7 @@ under the License.
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>aws-crt-client</artifactId>
-            <version>2.17.204-PREVIEW</version>
+            <version>2.20.101</version>
         </dependency>
 
         <!-- Test dependencies -->

--- a/integrations/flink_connector/flink-connector-timestream/src/test/java/com/amazonaws/samples/connectors/timestream/SinkInitContext.java
+++ b/integrations/flink_connector/flink-connector-timestream/src/test/java/com/amazonaws/samples/connectors/timestream/SinkInitContext.java
@@ -60,6 +60,11 @@ public class SinkInitContext implements InitContext {
         return 0;
     }
 
+    @Override
+    public int getAttemptNumber() {
+        return 1;
+    }
+
     /**
      * @return The metric group this writer belongs to.
      */

--- a/integrations/flink_connector/sample-kinesis-to-timestream-app/pom.xml
+++ b/integrations/flink_connector/sample-kinesis-to-timestream-app/pom.xml
@@ -29,8 +29,9 @@ under the License.
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <flink.version>1.15.3</flink.version>
-        <kda.version>2.0.0</kda.version>
+        <flink.version>1.17.1</flink.version>
+        <flink.connector.version>4.1.0-1.17</flink.connector.version>
+        <kda.version>2.1.0</kda.version>
         <kda.runtime.version>1.2.0</kda.runtime.version>
         <java.version>1.11</java.version>
         <jdk.version>11</jdk.version>
@@ -45,7 +46,7 @@ under the License.
             <dependency>
                 <groupId>software.amazon.awssdk</groupId>
                 <artifactId>bom</artifactId>
-                <version>2.17.203</version>
+                <version>2.20.101</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -93,7 +94,7 @@ under the License.
         <dependency>
             <groupId>org.apache.flink</groupId>
             <artifactId>flink-connector-kinesis</artifactId>
-            <version>${flink.version}</version>
+            <version>${flink.connector.version}</version>
         </dependency>
         <dependency>
             <groupId>com.amazonaws</groupId>
@@ -113,9 +114,9 @@ under the License.
         </dependency>
         <!-- For writing to Timestream -->
         <dependency>
-            <groupId>software.amazon.timestream</groupId>
+            <groupId>com.amazonaws.samples.connectors.timestream</groupId>
             <artifactId>flink-connector-timestream</artifactId>
-            <version>0.3</version>
+            <version>0.3-SNAPSHOT</version>
         </dependency>
 
         <!-- sdk dependencies -->


### PR DESCRIPTION
*AT-1457* https://bitquill.atlassian.net/browse/AT-1457

*Description of changes:*
Update flink and timestream connector cersion

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
