### PR TITLE
upgrade flink/bom dependency to use latest versions

### DIFF
--- a/integrations/flink_connector/flink-connector-timestream/pom.xml
+++ b/integrations/flink_connector/flink-connector-timestream/pom.xml
@@ -21,7 +21,7 @@ under the License.
     <modelVersion>4.0.0</modelVersion>
     <artifactId>flink-connector-timestream</artifactId>
     <groupId>com.amazonaws.samples.connectors.timestream</groupId>
-    <version>0.2-SNAPSHOT</version>
+    <version>0.3-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>flink-connector-timestream</name>
@@ -29,7 +29,7 @@ under the License.
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <flink.version>1.15.3</flink.version>
+        <flink.version>1.17.1</flink.version>
         <java.version>1.11</java.version>
         <jdk.version>11</jdk.version>
         <next.jdk.version>12</next.jdk.version>
@@ -42,7 +42,7 @@ under the License.
             <dependency>
                 <groupId>software.amazon.awssdk</groupId>
                 <artifactId>bom</artifactId>
-                <version>2.17.203</version>
+                <version>2.20.101</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
@@ -89,7 +89,7 @@ under the License.
         <dependency>
             <groupId>software.amazon.awssdk</groupId>
             <artifactId>aws-crt-client</artifactId>
-            <version>2.17.204-PREVIEW</version>
+            <version>2.20.101</version>
         </dependency>
 
         <!-- Test dependencies -->

--- a/integrations/flink_connector/flink-connector-timestream/src/test/java/com/amazonaws/samples/connectors/timestream/SinkInitContext.java
+++ b/integrations/flink_connector/flink-connector-timestream/src/test/java/com/amazonaws/samples/connectors/timestream/SinkInitContext.java
@@ -60,6 +60,11 @@ public class SinkInitContext implements InitContext {
         return 0;
     }
 
+    @Override
+    public int getAttemptNumber() {
+        return 1;
+    }
+
     /**
      * @return The metric group this writer belongs to.
      */

--- a/integrations/flink_connector/flink-connector-timestream/src/test/java/com/amazonaws/samples/connectors/timestream/SinkInitContext.java
+++ b/integrations/flink_connector/flink-connector-timestream/src/test/java/com/amazonaws/samples/connectors/timestream/SinkInitContext.java
@@ -62,7 +62,7 @@ public class SinkInitContext implements InitContext {
 
     @Override
     public int getAttemptNumber() {
-        return 1;
+        return 1; //The default number for writer to attempts in case of fail, 0 - no attempts
     }
 
     /**


### PR DESCRIPTION
## Summary
Flink application could not reach Timestream after version upgrade

## Description
Updates pom file with the new version of ***Flink 1.15.2***, after that change the runtime exception occurs for initialization ***connection: java.lang.NoSuchMethodError: 'org.apache.flink.metrics.MetricGroup org.apache.flink.api.connector.sink.Sink$InitContext.metricGroup()'***

For the fix all pom dependency has been updated with latest aws bom file and Flink dependencies to avoid interface incompatibility
Changes has been added to test cases to support new interface changes

## Related Issue
https://github.com/awslabs/amazon-timestream-tools/issues/122
https://github.com/awslabs/amazon-timestream-tools/issues/146

## Tests performed / created
Run existing unit tests: ***mvn clean test***

#### Verification by sample application:
### Precondition:
- Build connector: ***mvn clean package***
- Modify pom file for ***"sample-kinesis-to-timestream-app"*** to use the jar of packaged t***imestream-connector***
- Build sample application: ***mvn clean install***
- Run sample application: ***mvn install exec:java -Dexec.mainClass="com.amazonaws.samples.kinesis2timestream.StreamingJob" -Dexec.args="--InputStreamName TimestreamTestStream --Region us-east-1 --TimestreamDbName kdaflink --TimestreamTableName kinesisdata" -Dexec.classpathScope=test***

### Results
#### Before changes: 
The connector throw runtime exceptions: ***org.apache.flink.metrics.MetricGroup org.apache.flink.api.connector.sink.Sink$InitContext.metricGroup()***
Connector has not been established

#### After changes:
In the logs no error message and connector initialized, DB and required table created

## Additional Reviewers
@alexeytemnikov