### PR TITLE
fix pagination in query example

### DIFF
--- a/sample_apps/js/query-example.js
+++ b/sample_apps/js/query-example.js
@@ -239,7 +239,7 @@ export async function getAllRows(queryClient, query, nextToken) {
     });
 
     if (nextToken) {
-        params.NextToken = nextToken;
+        params.input.NextToken = nextToken
     }
 
     await queryClient.send(params).then(


### PR DESCRIPTION
The `QueryCommand` takes in an `input` object as an argument.:
```
const input = { // QueryRequest
  QueryString: "STRING_VALUE", // required
  ClientToken: "STRING_VALUE",
  NextToken: "STRING_VALUE",
  MaxRows: Number("int"),
};
const command = new QueryCommand(input);
```
Previous code was setting `NextToken` outside `input` object as such
```
{
  ...
  "input": {
    "QueryString": "SELECT * FROM ...",
    "MaxRows": 9
  },
  "NextToken": "AYABeH...."
}
```