### PR TITLE
use correct framework

### DIFF
--- a/sample_apps/dotnet/TimestreamDotNetSample.csproj
+++ b/sample_apps/dotnet/TimestreamDotNetSample.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>netcoreapp7.0</TargetFramework>
+    <TargetFramework>net7.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
netcoreapp was [replaced](https://learn.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-frameworks) with net since v5.

(regressed in https://github.com/awslabs/amazon-timestream-tools/pull/147)