### PR TITLE
Clarify host formatting for Influx migration script

### DIFF
--- a/tools/python/influx-migration/README.md
+++ b/tools/python/influx-migration/README.md
@@ -114,7 +114,7 @@ The following is a formatted version of the output:
 
 **`--dest-bucket DEST_BUCKET`**: Optional. The name of the InfluxDB bucket in the destination server, must not be an already existing bucket. Defaults to value of `--src-bucket` or `None` if `--src-bucket` not provided.
 
-**`--dest-host DEST_HOST`**: The host for the destination server. Example: http://localhost:8086.
+**`--dest-host DEST_HOST`**: The host for the destination server. Must have a scheme, domain or IP address, and port, e.g., `http://127.0.0.1:8086` or `https://<domain>:<port>`.
 
 **`--dest-org DEST_ORG`**: Optional. The name of the organization to restore buckets to in the destination server. If this is omitted, then all migrated buckets from the source server will retain their original organization and migrated buckets may not be visible in the destination server without creating and switching organizations. This value will be used in all forms of restoration whether a single bucket, a full migration, or any migration using csv files for backup and restoration.
 
@@ -134,7 +134,7 @@ The following is a formatted version of the output:
 
 **`--src-bucket SRC_BUCKET`**: Optional. The name of the InfluxDB bucket in the source server. If not provided, then `--full` must be provided.
 
-**`--src-host SRC_HOST`**: Optional. The host for the source server. Defaults to http://localhost:8086.
+**`--src-host SRC_HOST`**: Optional. The host for the source server. Must have a scheme, domain or IP address, and port, e.g., `http://127.0.0.1:8086` or `https://<domain>:<port>`. Defaults to http://localhost:8086 if no value is specified.
 
 > As mentioned previously, `mountpoint-s3` and `rclone` are needed if `--s3-bucket` is to be used, but can be ignored if the user doesn't provide a value for `--s3-bucket`, in which case backup files will be stored in a unique directory locally.
 
@@ -152,7 +152,7 @@ After meeting the prerequisites:
 
     b. Listing buckets with `influx bucket list -t <destination token> --host <destination host address> --skip-verify`.
 
-    c. Using `influx v1 shell -t <destination token> --host <destination host address> --skip-verify` and running `SELECT * FROM <migrated bucket>.<retention period>.<measurement name> LIMIT 100` to view contents of a bucket or `SELECT COUNT(*) FROM <migrated bucket>.<retention period>.<measurment name>` to verify the correct number of records have been migrated.
+    c. Using `influx v1 shell -t <destination token> --host <destination host address> --skip-verify` and running `SELECT * FROM <migrated bucket>.<retention period>.<measurement name> LIMIT 100` to view contents of a bucket or `SELECT COUNT(*) FROM <migrated bucket>.<retention period>.<measurement name>` to verify the correct number of records have been migrated.
 
     d. By running a query using `influx query -t <destination token> --host <destination host address> --skip-verify 'from(bucket: "<migrated bucket>") |> range(start: <desired start>, stop: <desired stop>)'`. Adding `|> count()` to the query is also a way to verify the correct number of records have been migrated.
 
@@ -178,7 +178,7 @@ After meeting the prerequisites:
 
     - (optional) S3 bucket name and credentials, AWS CLI credentials should be set in the OS environment variables.
       ```
-      # AWS credentials (for timestream testing)
+      # AWS credentials
       export AWS_ACCESS_KEY_ID="xxx"
       export AWS_SECRET_ACCESS_KEY="xxx"
       ```

--- a/tools/python/influx-migration/influx_migration.py
+++ b/tools/python/influx-migration/influx_migration.py
@@ -275,7 +275,7 @@ def health_check(host, token, skip_verify, debug=False):
     :returns: Whether the health check succeeded.
     :rtype: bool
     """
-    # Ensure hosts can be connected to
+    # Ensure host can be connected to
     try:
         client = InfluxDBClient(url=host,
             token=token, timeout=MILLISECOND_TIMEOUT, verify_ssl=not skip_verify, debug=debug)


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

- The help messages for `--src-host` and `--dest-host` have been updated to specify the expected url formatting.
- Host urls are now parsed and any missing fields are logged.
- The error log when a health check fails has been changed to indicate that it is an API call failure.
- A confusing comment in a code block in the README has been fixed.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
