### PR TITLE
Fix transform errors

### DIFF
--- a/tools/python/liveanalytics_migration_scripts/targets/timestream_for_influxdb/transform/README.md
+++ b/tools/python/liveanalytics_migration_scripts/targets/timestream_for_influxdb/transform/README.md
@@ -93,6 +93,7 @@ python3 transform.py \
 After the script has finished running:
 - In Athena, the table `example_database_example_table` will be created, containing Timestream for LiveAnalytics data.
 - In Athena, the table `lp_example_database_example_table` will be created, containing Timestream for LiveAnalytics data transformed to line protocol points.
+    - **NOTE**: The name of this table is needed later, when [validating ingested records](../validation/README.md), if `--source-engine` is set to `athena`.
 - In the S3 bucket `example_s3_bucket`, within the path `example_database/example_table/unload-<%Y-%m-%d-%H:%M:%S>/line-protocol-output`, line protocol data will be stored.
 
 ### Multiple Tables

--- a/tools/python/liveanalytics_migration_scripts/targets/timestream_for_influxdb/transform/README.md
+++ b/tools/python/liveanalytics_migration_scripts/targets/timestream_for_influxdb/transform/README.md
@@ -181,3 +181,15 @@ aws s3 rm s3://<S3 bucket name>/<Timestream database name>/<Timestream table nam
 
 The following limitations should be considered before transforming Timestream for LiveAnalytics records to line protocol:
 - The finest timestamp precision that Athena supports is **milliseconds**. If you need greater timestamp precision, such as microsecond or nanosecond precision, consider migrating to [Amazon RDS](https://aws.amazon.com/rds/).
+
+## Troubleshooting
+
+### Table Already Exists Error
+
+As part of the transformation process, two Athena tables are created. By default, these are `<Timestream database name>_<Timestream table name>` and `lp_<Timestream database name>_<Timestream table name>`. If these tables already exist, for example, from a previous run of the transformation script, the following exception will be raised:
+
+```
+RuntimeError: Athena query failed with state: FAILED, error: Table <table name> already exists.
+```
+
+To solve this error, delete the table indicated in the error and try running the transformation script again. To delete a table in Athena, see the [Cleanup](#cleanup) section.

--- a/tools/python/liveanalytics_migration_scripts/targets/timestream_for_influxdb/transform/README.md
+++ b/tools/python/liveanalytics_migration_scripts/targets/timestream_for_influxdb/transform/README.md
@@ -93,7 +93,7 @@ python3 transform.py \
 After the script has finished running:
 - In Athena, the table `example_database_example_table` will be created, containing Timestream for LiveAnalytics data.
 - In Athena, the table `lp_example_database_example_table` will be created, containing Timestream for LiveAnalytics data transformed to line protocol points.
-    - **NOTE**: The name of this table is needed later, when [validating ingested records](../validation/README.md), if `--source-engine` is set to `athena`.
+    - **NOTE**: The name of this table is needed later if [validating ingested records](../validation/README.md).
 - In the S3 bucket `example_s3_bucket`, within the path `example_database/example_table/unload-<%Y-%m-%d-%H:%M:%S>/line-protocol-output`, line protocol data will be stored.
 
 ### Multiple Tables

--- a/tools/python/liveanalytics_migration_scripts/targets/timestream_for_influxdb/transform/transform.py
+++ b/tools/python/liveanalytics_migration_scripts/targets/timestream_for_influxdb/transform/transform.py
@@ -246,19 +246,21 @@ def create_and_load_athena_table(
     try:
         # Expect the unload path to be
         # unload-%Y-%m-%d %H:%M:S
-        s3_unload_path = s3_utility.get_latest_unload_path(
+        latest_unload_path = s3_utility.get_latest_unload_path(
             bucket_name=s3_bucket_name,
             timestream_database_name=timestream_database_name,
             timestream_table_name=timestream_table_name,
         )
-        print(f"S3 unload path: {s3_unload_path}")
+        print(f"S3 unload path: {latest_unload_path}")
+        s3_unload_path = f"s3://{s3_bucket_name}/{timestream_database_name}/{timestream_table_name}/{latest_unload_path}"
         unload_query = f"""
                        CREATE EXTERNAL TABLE `{athena_database_name}`.`{athena_table_name}` ({", ".join(athena_columns)})
-                       STORED AS PARQUET LOCATION 's3://{s3_bucket_name}/{timestream_database_name}/{timestream_table_name}/{s3_unload_path}/results';
+                       STORED AS PARQUET LOCATION '{s3_unload_path}/results';
                        """
         transform_logger.info(f"Executing query: {unload_query}")
         response = athena_utility.start_query_execution(
             query_string=unload_query,
+            output_location=f"{s3_unload_path}/athena-query-results",
             database_name=athena_database_name,
         )
         query_execution_id = response["QueryExecutionId"]
@@ -429,11 +431,12 @@ def translate_athena_table_to_line_protocol(
     line_protocol_translation_result.tags.append(measure_name)
 
     try:
-        s3_unload_path = s3_utility.get_latest_unload_path(
+        latest_unload_path = s3_utility.get_latest_unload_path(
             bucket_name=s3_bucket_name,
             timestream_database_name=timestream_database_name,
             timestream_table_name=timestream_table_name,
         )
+        s3_unload_path = f"s3://{s3_bucket_name}/{timestream_database_name}/{timestream_table_name}/{latest_unload_path}"
         # Translate to line protocol.
         #
         # All column names are wrapped in quotes.
@@ -443,7 +446,7 @@ def translate_athena_table_to_line_protocol(
             CREATE TABLE "{athena_database_name}"."{lp_athena_table_name}"
             WITH (
                 format = 'TEXTFILE',
-                external_location = 's3://{s3_bucket_name}/{timestream_database_name}/{timestream_table_name}/{s3_unload_path}/line-protocol-output'
+                external_location = '{s3_unload_path}/line-protocol-output'
             ) AS
             SELECT
                 -- Measurement, from table name
@@ -495,7 +498,9 @@ def translate_athena_table_to_line_protocol(
 
         transform_logger.info(f"Executing query: {lp_translation_query}")
         response = athena_utlity.start_query_execution(
-            query_string=lp_translation_query, database_name=athena_database_name
+            query_string=lp_translation_query,
+            output_location=f"{s3_unload_path}/athena-query-results",
+            database_name=athena_database_name,
         )
         query_execution_id = response["QueryExecutionId"]
         transform_logger.info(f"Query execution ID: {query_execution_id}")
@@ -589,7 +594,7 @@ if __name__ == "__main__":
         "to help with post-migration validation. "
         "The field will be 'la_unload=1'.",
         required=True,
-        type=parse_bool_cli_argument
+        type=parse_bool_cli_argument,
     )
 
     args = parser.parse_args()

--- a/tools/python/liveanalytics_migration_scripts/unload/README.md
+++ b/tools/python/liveanalytics_migration_scripts/unload/README.md
@@ -63,6 +63,7 @@
 <div>
 <h2>Recommendations and Best Practices</h2>
 <ol>
+<li> Use a <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingBucket.html" target="_blank" title="Learn more about general purpose S3 buckets">general purpose S3 bucket</a>. </li>
 <li> If your target is <strong>Timestream for InfluxDB</strong> export in <strong>Parquet format</strong> and <strong>no compression</strong> to meet the ingestion scripts requirements place_holder </li>
 <li>Enable DynamoDB logging for tracking and validation</li>
 <li>Configure SNS notifications to receive failure or completion of export</li>

--- a/tools/python/liveanalytics_migration_scripts/unload/README.md
+++ b/tools/python/liveanalytics_migration_scripts/unload/README.md
@@ -63,7 +63,6 @@
 <div>
 <h2>Recommendations and Best Practices</h2>
 <ol>
-<li> Use a <a href="https://docs.aws.amazon.com/AmazonS3/latest/userguide/UsingBucket.html" target="_blank" title="Learn more about general purpose S3 buckets">general purpose S3 bucket</a>. </li>
 <li> If your target is <strong>Timestream for InfluxDB</strong> export in <strong>Parquet format</strong> and <strong>no compression</strong> to meet the ingestion scripts requirements place_holder </li>
 <li>Enable DynamoDB logging for tracking and validation</li>
 <li>Configure SNS notifications to receive failure or completion of export</li>

--- a/tools/python/liveanalytics_migration_scripts/unload/unload.py
+++ b/tools/python/liveanalytics_migration_scripts/unload/unload.py
@@ -60,7 +60,7 @@ if __name__ == "__main__":
 
     start_time= args.start_time 
     end_time= args.end_time
-    migration_tag = args.migration_tag or f"unload-{datetime.now(timezone.utc).strftime('%Y-%m-%d %H:%M:%S')}"
+    migration_tag = args.migration_tag or f"unload-{datetime.now(timezone.utc).strftime('%Y-%m-%d-%H:%M:%S')}"
     database = args.database
     table = args.table
     compression = args.compression

--- a/tools/python/liveanalytics_migration_scripts/unload/utils/athena_utils.py
+++ b/tools/python/liveanalytics_migration_scripts/unload/utils/athena_utils.py
@@ -19,10 +19,15 @@ class AthenaUtility:
         self.athena_client = boto3.client("athena", region_name=region)
         self.logger = create_logger("athena_logger")
 
-    def start_query_execution(self, query_string: str, database_name="default"):
+    def start_query_execution(
+        self, query_string: str, output_location: str, database_name="default"
+    ):
         return self.athena_client.start_query_execution(
             QueryString=query_string,
             QueryExecutionContext={"Database": database_name},
+            ResultConfiguration={
+                "OutputLocation": output_location,
+            },
         )
 
     def wait_for_athena_query(
@@ -53,9 +58,19 @@ class AthenaUtility:
         if state == "SUCCEEDED":
             self.logger.info("Query successful")
         else:
-            raise RuntimeError(
-                f"Query failed: {query_status['QueryExecution']['Status']}"
+            failure_state = (
+                query_status.get("QueryExecution", {})
+                .get("Status", {})
+                .get("State", "UNKNOWN")
             )
+            error_message = (
+                query_status.get("QueryExecution", {})
+                .get("Status", {})
+                .get("AthenaError", {})
+                .get("ErrorMessage", "UNKNOWN")
+            )
+            failure_message = f"Athena query failed with state: {failure_state}, error: {error_message}"
+            raise RuntimeError(failure_message)
 
     @staticmethod
     def is_valid_athena_table_name(athena_table_name: str) -> bool:

--- a/tools/python/liveanalytics_migration_scripts/unload/utils/s3_utils.py
+++ b/tools/python/liveanalytics_migration_scripts/unload/utils/s3_utils.py
@@ -129,7 +129,7 @@ class S3Utility:
             delimeter (str): The delimiter that separates paths within the S3
                 bucket. Defaults to "/".
             max_attempts (int): The maximum attempts to check whether any
-                mutlipart uplaods are in progress. Defaults to 20.
+                multipart uploads are in progress. Defaults to 20.
             base_delay (int): The base delay in seconds to use for
                 backoffs with exponential retries and jitter.
 

--- a/tools/python/liveanalytics_migration_scripts/unload/utils/s3_utils.py
+++ b/tools/python/liveanalytics_migration_scripts/unload/utils/s3_utils.py
@@ -1,7 +1,9 @@
+import random
 import boto3
 from logger_utils import create_logger
 import botocore
 import json
+import time
 
 
 class S3Utility:
@@ -89,6 +91,12 @@ class S3Utility:
         s3://<s3 bucket name>/<timestream database name>/<timestream table name>/unload-<%Y-%m-%d-%H:%M:%S>/results
         """
         prefix = f"{timestream_database_name}/{timestream_table_name}/"
+
+        # For general-purpose buckets, list_objects_v2 will not return
+        # prefixes while that prefix is related to an in-progress
+        # multipart upload.
+        self.wait_for_multipart_uploads(bucket_name=bucket_name, prefix=prefix)
+
         list_response = self.s3_client.list_objects_v2(
             Bucket=bucket_name, Prefix=prefix, Delimiter="/"
         )
@@ -107,3 +115,44 @@ class S3Utility:
         latest_dir = unload_dirs[-1]
         parts = latest_dir.rstrip("/").split("/")
         return parts[-1]
+
+    def wait_for_multipart_uploads(
+        self, bucket_name, prefix, delimeter="/", max_attempts=20, base_delay=1
+    ):
+        """
+        Waits for all multipart uploads related to a prefix within an S3 bucket
+        to complete or abort.
+
+        Args:
+            bucket_name (str): The name of the S3 bucket.
+            prefix (str): The prefix to check. For example, "benchmark22/cpu/".
+            delimeter (str): The delimiter that separates paths within the S3
+                bucket. Defaults to "/".
+            max_attempts (int): The maximum attempts to check whether any
+                mutlipart uplaods are in progress. Defaults to 20.
+            base_delay (int): The base delay in seconds to use for
+                backoffs with exponential retries and jitter.
+
+        Returns:
+            None
+        """
+        for attempt in range(max_attempts):
+            multipart_uploads = self.s3_client.list_multipart_uploads(
+                Bucket=bucket_name, Delimiter=delimeter, Prefix=prefix
+            ).get("Uploads", [])
+
+            if not multipart_uploads:
+                return
+
+            # Max 1 minute delay.
+            delay = min(base_delay * (2**attempt), 60)
+            # 10% jitter.
+            jitter = random.uniform(0, delay * 0.1)
+            sleep_time = delay + jitter
+            self.logger.info(
+                f"Multipart uploads are still in progress. Retrying in {sleep_time:.2f}s (attempt {attempt + 1})/{max_attempts})"
+            )
+            time.sleep(sleep_time)
+        raise TimeoutError(
+            f"Multipart uploads did not complete after {max_attempts} attempts"
+        )


### PR DESCRIPTION
*Issue #, if available:*

N/A.

*Description of changes:*

- Better error messages for failed Athena queries.
- The `unload-` path within a user's S3 bucket now uses a dash instead of a space in its path.
- S3 bucket path checking waits for multipart uploads to complete.
- Athena queries all use an output path, by default, within the `unload-` path.
- Troubleshooting section added to transformation README.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
