### PR TITLE
Fixes #225 - unsupported operand type(s) for |: 'type' and 'NoneType' in cardinality.py on Python < 3.10

### DIFF
--- a/tools/python/liveanalytics_migration_scripts/cardinality/cardinality.py
+++ b/tools/python/liveanalytics_migration_scripts/cardinality/cardinality.py
@@ -1,4 +1,5 @@
 import argparse
+from typing import Optional
 from datetime import datetime
 import sys
 
@@ -41,8 +42,8 @@ def get_live_analytics_cardinality(
     database_name: str,
     table_name: str,
     excluded_dimension_names=[],
-    start_time: datetime | None = None,
-    end_time: datetime | None = None,
+    start_time: Optional[datetime] = None,
+    end_time: Optional[datetime] = None,
 ) -> int:
     """
     Determines the cardinality of a Timestream for LiveAnalytics table, in accordance with


### PR DESCRIPTION
Fix for #225 - unsupported operand type(s) for |: 'type' and 'NoneType' in cardinality.py on Python < 3.10
*Issue #, if available:* #225

*Description of changes:*
Why needed?
Python 3.9.x is the default Python version in AWS Cloud9 and AWS CloudShell as of 5/20/2025. Fixing [Optional] handling so that this Python script  is runnable on Python < 3.10

Tested following command:
    ```
    python3 cardinality.py  --database-name sampledevopsdb --table-name DevOpsMulti
    2025-05-21 00:26:51,746 - cardinality - INFO - Executing query: DESCRIBE "sampledevopsdb"."DevOpsMulti"
    2025-05-21 00:26:52,331 - cardinality - INFO - Executing query: SELECT COUNT(DISTINCT(measure_name, hostname, az, region)) AS cardinality FROM "sampledevopsdb"."DevOpsMulti"
    Cardinality of "sampledevopsdb"."DevOpsMulti": 80
    Your recommended Timestream for InfluxDB instance type is: db.influx.medium
    ```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
