### PR TITLE
Add end-to-end migration wrapper script for InfluxDB V2 & V3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,9 @@ target/
 # Ignore common JS files
 node_modules
 
+# Ignore configs
+**/config.yaml
+
 # Ignore AWS Influx migration script backup and performance files and directories
 tools/python/influx-migration/**/performance.txt
 tools/python/influx-migration/**/*influxdb-backup-*
@@ -33,8 +36,7 @@ tools/python/influx-migration/**/scripts/temp/*
 **/query_results.log
 
 # LiveAnalytics to InfluxDB migration log files
-**/influxdb-ingestion-logs/**
-**/timestream-export-logs/**
+**/*-logs/
 
 # LiveAnalytics migration to InfluxDB generated test data
 tools/python/liveanalytics_migration_scripts/tests/integration/test-data/*

--- a/tools/python/liveanalytics_migration_scripts/requirements.txt
+++ b/tools/python/liveanalytics_migration_scripts/requirements.txt
@@ -4,3 +4,5 @@ python-dotenv==1.1.0
 requests==2.32.3
 psycopg2-binary==2.9.10
 pyarrow==20.0.0
+pyyaml==6.0.2
+pandas==2.2.3

--- a/tools/python/liveanalytics_migration_scripts/targets/timestream_for_influxdb/README.md
+++ b/tools/python/liveanalytics_migration_scripts/targets/timestream_for_influxdb/README.md
@@ -4,17 +4,15 @@
 
 Migration tooling for Timestream for InfluxDB allows you to easily transform your Timestream for LiveAnalytics data and ingest it to a Timestream for InfluxDB instance. Prior to performing the migration, ensure you have completed a cardinality assessment of the transformed schema to ensure Timestream for InfluxDB is a suitable migration target. See [../../cardinality/README.md](../../cardinality/README.md) for how to perform the cardinality assessment, and any potential schema alterations before starting the transformation process.
 
-Migrating to Timestream for InfluxDB takes multiple steps as the data models differ in how the data model is represented. See the Influx documentation for [getting started](https://docs.influxdata.com/influxdb/v2/get-started/) with InfluxDB V2 for an overview of the database key concepts.
+See the Influx documentation for [getting started](https://docs.influxdata.com/influxdb/v2/get-started/) with InfluxDB V2 for an overview of the database key concepts, as the data models differ from Timestream for LiveAnalytics in how the data model is represented.
 
 For best practices when designing your Timestream for InfluxDB deployment, see [Applying the AWS Well-Architected Framework for Amazon Timestream for InfluxDB](https://docs.aws.amazon.com/prescriptive-guidance/latest/timestream-for-influxdb-well-architected-framework/introduction.html).
 
-The workflow for completing a migration is separated into four stages:
-- [**Unload**](../../unload/README.md): Export your Timestream for LiveAnalytics dataset to S3
-- [**Data transformation**](./transform/README.md): Convert your Timestream for LiveAnalytics data to line protocol format (Based on the schema defined after the cardinality assessment)
-- [**Data ingestion**](./ingestion/README.md): Ingest the line protocol dataset to your Timestream for InfluxDB instance
-- [**Validation**](./validation/README.md): Optionally you can validate that every line protocol point has been ingested (Requires `--add-validation-field true` during transformation)
-
-See [End to end migration](#end-to-end-migration) for additional details on each step, and the migration diagram below for a visual workflow.
+Migration is composed of four stages:
+- [**Unload**](../../unload/README.md): Exports your Timestream for LiveAnalytics dataset to S3
+- [**Data transformation**](./transform/README.md): Converts your Timestream for LiveAnalytics data to line protocol format (Based on the schema defined after the cardinality assessment)
+- [**Data ingestion**](./ingestion/README.md): Ingests the line protocol dataset to your Timestream for InfluxDB instance
+- [**Validation**](./validation/README.md): Validates that line protocol has been ingested
 
 ```mermaid
 stateDiagram-v2
@@ -71,7 +69,75 @@ direction LR
 
 ## End-to-end Migration
 
-The following is an end-to-end example for migrating from a Timestream for LiveAnalytics database `benchmark` and table `cpu` to bucket `benchmark-bucket` in Timestream for InfluxDB (as defined in [example.env](example.env)).
+#### Prerequisites
+
+Ensure you have run the steps in [README.md#Installation](../../README.md#installation).
+
+- Migrating to <b>InfluxDB V2</b>
+
+    Define the following environment variables:
+    ```
+    export INFLUXDB_V2_URL="https://influxdb_v2_url:8086"
+    export INFLUXDB_V2_ORG="org"
+    export INFLUXDB_V2_TOKEN="xxx"
+    ```
+
+- Migrating to <b>InfluxDB V3</b>
+
+    InfluxDB V3 supports [backwards compatibility with prior versions (ie. the V2 write API)](https://docs.influxdata.com/influxdb3/enterprise/write-data/compatibility-apis/).
+
+    Define the following environment variables, omitting `INFLUXDB_V2_ORG` (concept of organizations do not apply in V3):
+    ```
+    export INFLUXDB_V2_URL="https://influxdb_v3_url:8181"
+    export INFLUXDB_V2_TOKEN="xxx"
+    ```
+
+    - Set `skip_bucket_check` in the config to `True` (concept of buckets do not apply in V3)
+
+#### Usage
+
+Run `main.py` with the path to your config file which will handle all 4 stages of the migration:
+
+```
+python main.py --config <path_to_config>
+```
+
+Refer to [the example config](example.migration-config.yaml) for the full set of configurable options.
+
+##### Example Scenarios
+
+- Migrate all databases and tables (in given region):
+
+    ```
+    source:
+      all_databases: true
+    ```
+
+- Migrate tables `cpu`, `memory` from database `database1` and all tables from `database2`:
+
+    ```
+    source:
+      all_databases: false
+      databases:
+        database1:
+          - cpu
+          - memory
+        database2:
+    ```
+
+- Transform dimension `hostname` to field from `database1`.`cpu`:
+
+    ```
+      transform:
+        dimensions_to_fields:
+          database1:
+            cpu:
+              - hostname
+    ```
+
+## Sample Workflow for Manual Migrations
+
+The following is a step-by-step workflow for performing a manual migration from a Timestream for LiveAnalytics database `benchmark` and table `cpu` to bucket `benchmark-bucket` in Timestream for InfluxDB V2.
 
 ###  1. Transform data from Timestream
 
@@ -83,7 +149,7 @@ python3 transform.py --database-name benchmark --tables cpu --s3-bucket-path <s3
 ```
 
 - To transform all tables, use the `--all-tables` flag.
-- If end-to-end validation (comparing logical row counts between source and destination) is not required, set `--add-validation-field` flag to `false`.
+- If validation (comparing logical row counts between source and destination) is not required, set `--add-validation-field` flag to `false`.
 - To convert dimensions to fields during transformation, use the `--dimensions-to-fields` flag.
 
 See [transform/README.md](./transform/README.md) for more details.
@@ -93,6 +159,13 @@ See [transform/README.md](./transform/README.md) for more details.
 Download transformed LP dataset from S3:
 ```
 aws s3 sync s3://<s3_bucket_name>/benchmark/cpu/unload-<%Y-%m-%d-%H-%M-%S>/line-protocol-output ./line-protocol-output
+```
+
+Define required environment variables:
+```
+export INFLUXDB_V2_URL="https://influxdb_v2_url:8086"
+export INFLUXDB_V2_ORG="org"
+export INFLUXDB_V2_TOKEN="xxx"
 ```
 
 Run the ingestion script with the target Timestream for InfluxDB bucket and path to your downloaded LP dataset:
@@ -120,7 +193,7 @@ python3 validation/validator.py
 
 - If any dimensions were converted to fields during transformation to LP, provide the full list of tags from the new schema. Refer to the output of the [transformation](transform/README.md#using-dimensions-as-fields) to retrieve tags from the transformed schema.
 
-- To check current ingestion progress without impacting the migration, use the validator with `--influx-only` and `--skip-wal-check` flags. This provides a real-time count of points in Timestream for InfluxDB without querying the source database (Athena/Timestream for LiveAnalytics) and excludes records still in post-processing.
+- To check current ingestion progress without impacting the migration, run the validator with `--influx-only` and `--skip-wal-check` flags. This provides a real-time count of points in Timestream for InfluxDB without querying the source database (Athena/Timestream for LiveAnalytics) and excludes records still in post-processing.
 
     ```
     python3 validation/validator.py --skip-wal-check --influx-only
@@ -151,7 +224,9 @@ See [validation/README.md](./validation/README.md) for more details.
     which python
     ```
 
-- Ensure required environment variables are defined, or `.env` (see [example.env](example.env)) is present when running scripts in this directory. Note that ingestion  requires the following environment variables to be defined:
+- Ensure required environment variables (for ingestion) are defined:
     - `INFLUXDB_V2_URL`
     - `INFLUXDB_V2_ORG`
     - `INFLUXDB_V2_TOKEN`
+
+    Note that you can omit `INFLUXDB_V2_ORG` for migrations to InfluxDB V3.

--- a/tools/python/liveanalytics_migration_scripts/targets/timestream_for_influxdb/example.migration-config.yaml
+++ b/tools/python/liveanalytics_migration_scripts/targets/timestream_for_influxdb/example.migration-config.yaml
@@ -1,0 +1,70 @@
+version: 1.0
+
+global:
+  aws_region: us-west-2
+  logs_dir: ./migration-logs
+  num_threads: 4
+  # s3_uri: s3://amzn-s3-demo-bucket # Must exist
+
+source:
+  all_databases: false
+  databases:
+    database1:
+      - cpu
+      - memory
+    database2:
+
+stage:
+  #######################################################################
+  # UNLOAD
+  #######################################################################
+  unload:
+    # migration_tag: unload-YYYY-MM-DD-HH-mm-SS
+    encryption: SSE_S3
+    kms_key: null
+    sns_topic_arn: null
+    start_time: "2000-01-01 00:00:00"
+    end_time:   "2026-01-01 00:00:00"
+    partition: year
+    export_format: PARQUET
+    compression: NONE
+    custom_partition_count: 99
+    recent_first: false
+    append_timestamps: true
+    max_file_size: 78GB
+    enable_dynamodb_logger: false
+    field_delimiter: ","
+    escaped_by: "\\"
+    order_by_asc: false
+    logs_dir: unload-logs
+
+  #######################################################################
+  # TRANSFORM
+  #######################################################################
+  transform:
+    athena_database_name: default
+    dimensions_to_fields: {}
+    # dimensions_to_fields:
+    #   database1:
+    #     cpu:
+    #       - hostname
+    add_validation_field: true
+    logs_dir: transform-logs
+
+  #######################################################################
+  # INGESTION
+  #######################################################################
+  ingest:
+    lines_per_batch: 5000
+    io_multiplier: 5
+    retries: 20
+    precision: ns
+    logs_dir: ingestion-logs
+    continue_on_error: true
+    skip_bucket_check: false
+
+  #######################################################################
+  # VALIDATION
+  #######################################################################
+  validation:
+    logs_dir: validation-logs

--- a/tools/python/liveanalytics_migration_scripts/targets/timestream_for_influxdb/ingestion/influxdb_ingestion.py
+++ b/tools/python/liveanalytics_migration_scripts/targets/timestream_for_influxdb/ingestion/influxdb_ingestion.py
@@ -15,8 +15,11 @@ import multiprocessing
 from multiprocessing import Pool, current_process, Value
 from influxdb_client import InfluxDBClient
 from influxdb_client.client.write_api import SYNCHRONOUS
+from unload.utils.logger_utils import update_logger
 
 from dotenv import load_dotenv
+
+ingestion_logger = logging.getLogger("ingestion")
 
 # Custom exceptions for better error handling
 class InfluxDBIngestionError(Exception):
@@ -30,12 +33,13 @@ class FileExtractionError(Exception):
 
 
 # Check that all environment variables have been set
-def check_required_env_vars():
+def check_required_env_vars(skip_bucket_check):
     required_vars = [
         'INFLUXDB_V2_URL',
-        'INFLUXDB_V2_ORG',
         'INFLUXDB_V2_TOKEN'
     ]
+    if not skip_bucket_check:
+        required_vars.append('INFLUXDB_V2_ORG')
 
     missing_vars = []
     for var in required_vars:
@@ -68,13 +72,13 @@ def check_bucket_exists(bucket_name):
         bucket_exists = any(bucket.name == bucket_name for bucket in buckets)
 
         if bucket_exists:
-            logging.info(f"Bucket '{bucket_name}' exists. Proceeding with ingestion.")
+            ingestion_logger.info(f"Bucket '{bucket_name}' exists. Proceeding with ingestion.")
             return True
         else:
-            logging.error(f"Bucket '{bucket_name}' does not exist. Create the bucket before ingestion.")
+            ingestion_logger.error(f"Bucket '{bucket_name}' does not exist. Create the bucket before ingestion.")
             return False
     except Exception as e:
-        logging.error(f"Error checking if bucket '{bucket_name}' exists: {e}")
+        ingestion_logger.error(f"Error checking if bucket '{bucket_name}' exists: {e}")
         return False
     finally:
         if client:
@@ -93,39 +97,15 @@ def check_org_exists():
         org_api = client.organizations_api()
         orgs = org_api.find_organizations(org=client.org)
         if orgs:
-            logging.info("Organization '%s' exists – proceeding.", client.org)
+            ingestion_logger.info("Organization '%s' exists – proceeding.", client.org)
             return True
         return False
     except Exception as exc:
-        logging.error("Error checking if organization '%s' exists: %s", client.org, exc)
+        ingestion_logger.error("Error checking if organization '%s' exists: %s", client.org, exc)
         return False
     finally:
         if client:
             client.close()
-
-def setup_logging(log_dir=None):
-    """Safe logging for multiprocessing"""
-    if log_dir is None:
-        log_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'influxdb-ingestion-logs')
-
-    os.makedirs(log_dir, exist_ok=True)
-
-    log_file = os.path.join(log_dir, f'ingestion_log_{time.strftime("%Y%m%d_%H%M%S")}.log')
-
-    log_format = '%(asctime)s - %(processName)s - %(levelname)s - %(message)s'
-
-    logging.basicConfig(
-        level=logging.INFO,
-        format=log_format,
-        handlers=[
-            logging.FileHandler(log_file),
-            logging.StreamHandler()  # Also output to console
-        ]
-    )
-
-    logging.info(f"Logging initialized to {log_file}")
-    return log_file
-
 
 def update_tracking_file(file_path, file_name, success=True):
     """
@@ -140,12 +120,11 @@ def update_tracking_file(file_path, file_name, success=True):
         with open(file_path, 'a', encoding='utf-8') as f:
             f.write(f"{file_name}\n")
             f.flush()
-
         log_level = logging.INFO if success else logging.ERROR
         log_message = f"{'Successfully ingested' if success else 'Failed to ingest'}: {file_name}"
-        logging.log(log_level, log_message)
+        ingestion_logger.log(log_level, log_message)
     except Exception as e:
-        logging.error(f"Error updating tracking file {file_path}: {e}")
+        ingestion_logger.error(f"Error updating tracking file {file_path}: {e}")
 
 
 def find_latest_ingested_files(tracking_directory):
@@ -160,17 +139,15 @@ def find_latest_ingested_files(tracking_directory):
     """
     ingested_files = set()
     prev_success_log = os.path.join(tracking_directory, "ingested_files.txt")
-
     if os.path.exists(prev_success_log):
         try:
             with open(prev_success_log, 'r', encoding='utf-8') as f:
                 ingested_files = set(line.strip() for line in f)
-            logging.info(f"Found {len(ingested_files)} previously ingested files in {prev_success_log}")
+            ingestion_logger.info(f"Found {len(ingested_files)} previously ingested files in {prev_success_log}")
         except Exception as e:
-            logging.error(f"Error reading previous successful files: {e}")
+            ingestion_logger.error(f"Error reading previous successful files: {e}")
     else:
-        logging.info(f"No successful files log found in {tracking_directory}")
-
+        ingestion_logger.info(f"No successful files log found in {tracking_directory}")
     return ingested_files
 
 
@@ -189,15 +166,14 @@ def decompress_gzip_file(gz_file_path):
     """
     # Remove .gz extension and add .line
     extracted_file_path = gz_file_path[:-3] if gz_file_path.endswith('.gz') else f"{gz_file_path}.line"
-
-    logging.info(f"Extracting {gz_file_path} to {extracted_file_path}")
+    ingestion_logger.info(f"Extracting {gz_file_path} to {extracted_file_path}")
     try:
         with gzip.open(gz_file_path, 'rb') as f_in:
             with open(extracted_file_path, 'wb') as f_out:
                 shutil.copyfileobj(f_in, f_out)
         return extracted_file_path
     except Exception as exc:
-        logging.error(f"Error decompressing file {gz_file_path}: {exc}")
+        ingestion_logger.error(f"Error decompressing file {gz_file_path}: {exc}")
         raise FileExtractionError(f"Failed to decompress {gz_file_path}") from exc
 
 
@@ -229,19 +205,19 @@ def ingest_batch(write_api, batch, batch_id, process_name, bucket_name, max_retr
     while ingestion_attempt <= max_retries:
         try:
             if ingestion_attempt == 1:
-                logging.info(f"{process_name} - Writing batch {batch_id} of {len(batch)} lines")
+                ingestion_logger.info(f"{process_name} - Writing batch {batch_id} of {len(batch)} lines")
             else:
-                logging.warning(f"{process_name} - Retry attempt {ingestion_attempt} for batch {batch_id}")
+                ingestion_logger.warning(f"{process_name} - Retry attempt {ingestion_attempt} for batch {batch_id}")
 
             write_api.write(bucket=bucket_name, record=batch_content, write_precision=precision)
 
-            logging.info(f"{process_name} - Successfully wrote batch {batch_id} on attempt #{ingestion_attempt}")
+            ingestion_logger.info(f"{process_name} - Successfully wrote batch {batch_id} on attempt #{ingestion_attempt}")
             return len(batch)
 
         except Exception as write_exc:
             ingestion_attempt += 1
             if ingestion_attempt > max_retries:
-                logging.error(f"{process_name} - Failed to write batch {batch_id} after {max_retries} retries: {write_exc}")
+                ingestion_logger.error(f"{process_name} - Failed to write batch {batch_id} after {max_retries} retries: {write_exc}")
                 raise InfluxDBIngestionError(f"Failed to write batch {batch_id} after {max_retries} retries") from write_exc
 
             # Calculate backoff with jitter
@@ -250,8 +226,8 @@ def ingest_batch(write_api, batch, batch_id, process_name, bucket_name, max_retr
             random_jitter = random.uniform(0, jitter_ms)
             delay_with_jitter = delay_ms + random_jitter
 
-            logging.warning(f"{process_name} - Retry attempt for batch {batch_id} due to error: {write_exc}")
-            logging.warning(f"{process_name} - Waiting {delay_with_jitter/1000:.2f} seconds before retry #{ingestion_attempt +1}")
+            ingestion_logger.warning(f"{process_name} - Retry attempt for batch {batch_id} due to error: {write_exc}")
+            ingestion_logger.warning(f"{process_name} - Waiting {delay_with_jitter/1000:.2f} seconds before retry #{ingestion_attempt +1}")
 
             # Sleep before retry (convert ms to seconds)
             time.sleep(delay_with_jitter / 1000)
@@ -335,7 +311,7 @@ def ingest_line_protocol_file(extracted_file_path, lines_per_batch, io_multiplie
     with InfluxDBClient.from_env_properties() as client:
         write_api = client.write_api(write_options=SYNCHRONOUS)
 
-        logging.info(f"ingesting contents of {extracted_file_path}")
+        ingestion_logger.info(f"ingesting contents of {extracted_file_path}")
         with open(extracted_file_path, 'r', encoding='utf-8') as f:
             while True:
                 outer_chunk = read_outer_chunks(f, lines_per_batch, io_multiplier)
@@ -351,7 +327,7 @@ def ingest_line_protocol_file(extracted_file_path, lines_per_batch, io_multiplie
     return total_lines
 
 
-def ingest_gzip_file(gz_file_path, lines_per_batch, io_multiplier, bucket_name, max_retries, precision):
+def ingest_gzip_file(gz_file_path, lines_per_batch, io_multiplier, bucket_name, max_retries, precision, logs_dir):
     """
     Ingest a gzip file to InfluxDB.
 
@@ -369,6 +345,7 @@ def ingest_gzip_file(gz_file_path, lines_per_batch, io_multiplier, bucket_name, 
     Raises:
         Exception: If any error occurs during ingestion
     """
+    update_logger(ingestion_logger, logs_dir, f"worker-{current_process().pid}.log")
     process_name = current_process().name
     start_time = time.time()
     total_lines = 0
@@ -381,7 +358,7 @@ def ingest_gzip_file(gz_file_path, lines_per_batch, io_multiplier, bucket_name, 
 
     duration = time.time() - start_time
     lines_per_sec = total_lines/duration if duration > 0 else 0
-    logging.info(
+    ingestion_logger.info(
         "Process %s finished ingesting %s: %d lines in %.2f seconds (%.2f lines/sec)",
         process_name, file_name, total_lines, duration, lines_per_sec
     )
@@ -389,9 +366,9 @@ def ingest_gzip_file(gz_file_path, lines_per_batch, io_multiplier, bucket_name, 
     if extracted_file_path and os.path.exists(extracted_file_path):
         try:
             os.remove(extracted_file_path)
-            logging.info("%s deleted.", extracted_file_path)
+            ingestion_logger.info("%s deleted.", extracted_file_path)
         except Exception as exc:
-            logging.error("Error deleting extracted file %s: %s", extracted_file_path, exc)
+            ingestion_logger.error("Error deleting extracted file %s: %s", extracted_file_path, exc)
 
 
     return total_lines
@@ -421,22 +398,22 @@ def poll_for_result(result, failure_flag, continue_on_error, failed_log, file_na
             if failure_flag.value == 1:
                 update_tracking_file(failed_log, file_name, success=False)
                 if continue_on_error:
-                    logging.warning(f"Error detected in file {file_name}, but continuing with next file")
+                    ingestion_logger.warning(f"Error detected in file {file_name}, but continuing with next file")
                     return 0
                 else:
-                    logging.error("Stopping ingestion due to error in file %s.", file_name)
-                    logging.error("Fix the issue and run with --resume-from with the path to the previous tracking folder.")
+                    ingestion_logger.error("Stopping ingestion due to error in file %s.", file_name)
+                    ingestion_logger.error("Fix the issue and run with --resume-from with the path to the previous tracking folder.")
                     sys.exit(1)
             continue
             # We also need this exception block to handle InfluxDBIngestionError
         except Exception as e:
             update_tracking_file(failed_log, file_name, success=False)
             if continue_on_error:
-                logging.warning(f"Continuing with next file after error {e} in {file_name}")
+                ingestion_logger.warning(f"Continuing with next file after error {e} in {file_name}")
                 return 0
             else:
-                logging.error(f"Stopping ingestion due to error {e} in file {file_name}.")
-                logging.error("Fix the issue and run with --resume-from with the path to the previous tracking folder.")
+                ingestion_logger.error(f"Stopping ingestion due to error {e} in file {file_name}.")
+                ingestion_logger.error("Fix the issue and run with --resume-from with the path to the previous tracking folder.")
                 sys.exit(1)
 
 def main(input_args):
@@ -462,16 +439,19 @@ def main(input_args):
     parser.add_argument('-p', '--precision', type=str, default='ns',
                         choices=['ns', 'ms', 'us', 's'],
                         help='Timestamp precision for InfluxDB write. Note that this must align with the timestamp precision from the data being ingested (default: ns)')
+    parser.add_argument('--skip-bucket-check', action='store_true',
+                        help='Skips bucket and organization check (for ingestions to V3)')
     args = parser.parse_args(input_args)
 
-    setup_logging()
+    log_file_name = f'ingestion_{time.strftime("%Y%m%d_%H%M%S")}.log'
+    update_logger(ingestion_logger, args.logs_dir, log_file_name)
 
-    check_required_env_vars()
-    if not check_bucket_exists(args.bucket) or not check_org_exists():
+    check_required_env_vars(args.skip_bucket_check)
+    if not args.skip_bucket_check and (not check_bucket_exists(args.bucket) or not check_org_exists()):
         sys.exit(1)
 
     if not os.path.isdir(args.data_directory):
-        logging.error(f"Error: {args.data_directory} is not a valid directory")
+        ingestion_logger.error(f"Error: {args.data_directory} is not a valid directory")
         sys.exit(1)
 
     # Create a success and failure file tracking directory
@@ -494,18 +474,18 @@ def main(input_args):
             if os.path.basename(file_path) not in ingested_files:
                 gz_files.append(file_path)
             else:
-                logging.info(f"Skipping already ingested file: {file}")
+                ingestion_logger.info(f"Skipping already ingested file: {file}")
 
     if not gz_files:
-        logging.warning(f"No .gz files found to ingest in {args.data_directory}")
-        sys.exit(1)
+        ingestion_logger.warning(f"No .gz files found to ingest in {args.data_directory}")
+        return
 
-    logging.info(f"Found {len(gz_files)}.gz files in directory {args.data_directory}")
-    logging.info(f"Using {args.workers} workers to handle extraction and ingestion")
+    ingestion_logger.info(f"Found {len(gz_files)}.gz files in directory {args.data_directory}")
+    ingestion_logger.info(f"Using {args.workers} workers to handle extraction and ingestion")
 
     start_time = time.time()
     total_lines_ingested = 0
-    logging.info(f"Continue-on-error mode: {'enabled' if args.continue_on_error else 'disabled'}")
+    ingestion_logger.info(f"Continue-on-error mode: {'enabled' if args.continue_on_error else 'disabled'}")
 
     with Pool(processes=args.workers) as pool:
         async_results = []
@@ -519,45 +499,42 @@ def main(input_args):
             # Closure to capture the specific file's failure flag
             def make_error_callback(file_flag):
                 def error_callback(e):
-                    logging.error(f"Worker ingestion error: {e}")
+                    ingestion_logger.error(f"Worker ingestion error: {e}")
                     with file_flag.get_lock():
                         file_flag.value = 1
                 return error_callback
 
             result = pool.apply_async(
                 ingest_gzip_file,
-                args=(file, args.lines, args.multiplier, args.bucket, args.retries, args.precision),
+                args=(file, args.lines, args.multiplier, args.bucket, args.retries, args.precision, args.logs_dir),
                 error_callback=make_error_callback(failure_flags[file_name])
             )
             async_results.append((file, result))
-
         for file_path, result in async_results:
             file_name = os.path.basename(file_path)
-
             lines = poll_for_result(result, failure_flags[file_name], args.continue_on_error, failed_log, file_name)
-
             if lines > 0:
                 total_lines_ingested += lines
                 update_tracking_file(success_log, file_name, success=True)
-                logging.info(f"Successfully ingested file: {file_name}")
+                ingestion_logger.info(f"Successfully ingested file: {file_name}")
             else:
-                logging.error(f"Failed to ingest: {file_name}")
-                logging.warning(f"Continuing with next file after error in {file_name}")
+                ingestion_logger.error(f"Failed to ingest: {file_name}")
+                ingestion_logger.warning(f"Continuing with next file after error in {file_name}")
 
     # Log summary statistics
     total_time = time.time() - start_time
-    logging.info("Unload ingestion complete with a processing time: %.2f seconds", total_time)
-    logging.info("Total number of lines ingested: %d", total_lines_ingested)
+    ingestion_logger.info("Unload ingestion complete with a processing time: %.2f seconds", total_time)
+    ingestion_logger.info("Total number of lines ingested: %d", total_lines_ingested)
     if total_time > 0:
-        logging.info("Overall ingestion rate: %.2f lines/second", total_lines_ingested / total_time)
+        ingestion_logger.info("Overall ingestion rate: %.2f lines/second", total_lines_ingested / total_time)
 
     successful_count = sum(1 for _ in open(success_log, encoding='utf-8')) if os.path.exists(success_log) else 0
     failed_count = sum(1 for _ in open(failed_log, encoding='utf-8')) if os.path.exists(failed_log) else 0
 
-    logging.info(f"Successfully ingested {successful_count} files.")
+    ingestion_logger.info(f"Successfully ingested {successful_count} files.")
     if failed_count > 0:
-        logging.error(f"Failed to ingest {failed_count} files.")
-        logging.error("To retry failed files, run the script with the --resume-from with the path to the previous tracking folder.")
+        ingestion_logger.error(f"Failed to ingest {failed_count} files.")
+        ingestion_logger.error("To retry failed files, run the script with the --resume-from with the path to the previous tracking folder.")
 
 if __name__ == "__main__":
     main(sys.argv[1:])

--- a/tools/python/liveanalytics_migration_scripts/targets/timestream_for_influxdb/main.py
+++ b/tools/python/liveanalytics_migration_scripts/targets/timestream_for_influxdb/main.py
@@ -1,0 +1,485 @@
+import sys
+import argparse
+import shutil
+import os
+import yaml
+import logging
+from boto3 import Session
+from datetime import datetime, timezone
+from influxdb_client import InfluxDBClient
+from concurrent.futures import ThreadPoolExecutor
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../")))
+
+
+from unload import main as unload_main
+from unload.utils.s3_utils import S3Utility
+from unload.utils.logger_utils import update_logger
+from unload.utils.timestream_utils import TimestreamUtility
+from targets.timestream_for_influxdb.transform import transform
+from targets.timestream_for_influxdb.ingestion import influxdb_ingestion
+from targets.timestream_for_influxdb.validation import validator
+
+migration_logger = logging.getLogger("e2e-migration")
+
+def to_iso_z(dt_str):
+    return datetime.fromisoformat(dt_str).replace(tzinfo=timezone.utc).isoformat().replace('+00:00', 'Z')
+
+def echo_config(d, indent=0):
+    """Recursively print nested dictionary values with indentation."""
+    for key, value in d.items():
+        prefix = '  ' * indent
+        if isinstance(value, dict):
+            migration_logger.info(f"{prefix}{key}:")
+            echo_config(value, indent + 1)
+        else:
+            migration_logger.info(f"{prefix}{key}: {value}")
+
+def cleanup_athena(glue, athena_database, timestream_database, timestream_tables):
+    for table in timestream_tables:
+        athena_table_name = (
+            timestream_database.replace("-", "_")
+            + "_"
+            + table.replace("-", "_")
+        )
+        athena_lp_table_name = f"lp_{athena_table_name}"
+        try:
+            migration_logger.info(f"Deleting {athena_table_name} from {athena_database}")
+            glue.delete_table(
+                DatabaseName=athena_database, Name=athena_table_name
+            )
+        except Exception:
+            migration_logger.error(f"Error deleting {athena_table_name} from {athena_database}")
+        try:
+            migration_logger.info(f"Deleting {athena_lp_table_name} from {athena_database}")
+            glue.delete_table(
+                DatabaseName=athena_database, Name=athena_lp_table_name
+            )
+        except Exception:
+            migration_logger.error(f"Error deleting {athena_table_name} from {athena_database}")
+
+def create_athena_db_if_not_exists(boto_session, athena_database_name):
+    glue_client = boto_session.client("glue")
+    migration_logger.info(f"Checking Athena for database: {athena_database_name}")
+    try:
+        glue_client.get_database(Name=athena_database_name)
+        migration_logger.info(f"Database '{athena_database_name}' already exists.")
+    except glue_client.exceptions.EntityNotFoundException:
+        glue_client.create_database(
+            DatabaseInput={"Name": athena_database_name}
+        )
+        migration_logger.info(f"Database '{athena_database_name}' created successfully.")
+    finally:
+        glue_client.close()
+
+def execute_jobs(func, func_args, num_threads=4):
+    with ThreadPoolExecutor(max_workers=num_threads) as executor:
+        futures = [executor.submit(func, args) for args in func_args]
+        results = [future.result() for future in futures]
+        migration_logger.info(f"Finished {len(results)} runs.")
+
+def load_config(path):
+    if not os.path.exists(path):
+        raise FileNotFoundError(f"Config file not found: {path}")
+    with open(path, 'r') as file:
+        if path.endswith(('.yaml', '.yml')):
+            return yaml.safe_load(file)
+        else:
+            raise ValueError("Unsupported config format. Use .yaml/.yml")
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Perform an end-to-end migration from Timestream for LiveAnalytics to InfluxDB V2/V3.")
+    parser.add_argument(
+        "--config",
+        nargs="?",
+        const="config.yaml",
+        default="config.yaml",
+        help="Optional path to config file (default: config.yaml)"
+    )
+    args = parser.parse_args()
+    config = load_config(args.config)
+
+    # ---------
+    # global configs
+    # ---------
+    aws_region = config["global"]["aws_region"]
+    os.environ["AWS_DEFAULT_REGION"] = aws_region
+
+    s3_uri = config["global"].get(
+        "s3_uri",
+        f"s3://influxdb-migration-{datetime.now(timezone.utc).strftime('%Y%m%d-%H%M%S')}"
+    )
+    base_logs_dir = config["global"]["logs_dir"]
+    num_threads = config["global"]["num_threads"]
+
+    # setup logger
+    log_file_name = f'migration_{datetime.now(timezone.utc).strftime('%Y%m%d_%H%M%S')}.log'
+    update_logger(migration_logger, base_logs_dir, log_file_name)
+
+    # ---------
+    # source database configs
+    # ---------
+    all_databases = config['source'].get("all_databases", False)
+    db_table_map = config["source"].get("databases", None)
+
+    migration_logger.info("Beginning migration to InfluxDB")
+    migration_logger.info("-"*20)
+    migration_logger.info(f"Loaded configs from '{args.config}'")
+    echo_config(config)
+
+    if not all_databases and not db_table_map:
+        migration_logger.error(f"Specify source databases to migrate in {args.config}")
+        return
+    
+    # ---------
+    # UNLOAD configs
+    # ---------
+    migration_tag = config["stage"]["unload"].get(
+        "migration_tag",
+        f"unload-{datetime.now(timezone.utc).strftime('%Y%m%d_%H%M%S')}"
+    )
+    encryption = config["stage"]["unload"]["encryption"]
+    kms_key = config["stage"]["unload"]["kms_key"]
+    sns_topic_arn = config["stage"]["unload"]["sns_topic_arn"]
+    unload_start_time = config["stage"]["unload"]["start_time"]
+    unload_end_time = config["stage"]["unload"]["end_time"]
+    partition = config["stage"]["unload"]["partition"]
+    export_format = config["stage"]["unload"]["export_format"]
+    compression = config["stage"]["unload"]["compression"]
+    custom_partition_count = config["stage"]["unload"]["custom_partition_count"]
+    recent_first = config["stage"]["unload"]["recent_first"]
+    append_timestamps = config["stage"]["unload"]["append_timestamps"]
+    max_file_size = config["stage"]["unload"]["max_file_size"]
+    enable_dynamodb_logger = config["stage"]["unload"]["enable_dynamodb_logger"]
+    field_delimiter = config["stage"]["unload"]["field_delimiter"]
+    escaped_by = config["stage"]["unload"]["escaped_by"]
+    order_by_asc = config["stage"]["unload"]["order_by_asc"]
+    unload_logs_dir = os.path.join(base_logs_dir, config["stage"]["unload"]["logs_dir"])
+
+    unload_common_args = [
+        "--s3-uri", s3_uri,
+        "--migration-tag", migration_tag,
+        "--encryption", encryption,
+        "--kms-key", kms_key, 
+        "--sns-topic-arn", sns_topic_arn, 
+        "--start-time", unload_start_time, 
+        "--end-time", unload_end_time, 
+        "--partition", partition,
+        "--export-format", export_format, 
+        "--compression", compression,
+        "--custom-partition-count", str(custom_partition_count),
+        "--recent-first", str(recent_first), 
+        "--append-timestamps", str(append_timestamps), 
+        "--max-file-size", max_file_size,
+        "--enable-dynamodb-logger", str(enable_dynamodb_logger), 
+        "--field-delimiter", field_delimiter, 
+        "--escaped-by", escaped_by, 
+        "--order-by-asc", str(order_by_asc),
+        "--logs-dir", unload_logs_dir, 
+    ]
+    
+    # ---------
+    # TRANSFORM configs
+    # ---------
+    athena_database_name = config["stage"]["transform"]["athena_database_name"]
+    dimensions_to_fields_map = config["stage"]["transform"].get("dimensions_to_fields", {})
+    add_validation_field = config["stage"]["transform"]["add_validation_field"]
+    transform_logs_dir = os.path.join(base_logs_dir, config["stage"]["transform"]["logs_dir"])
+
+    transform_common_args = [
+        "--s3-bucket-path", s3_uri,
+        "--athena-database-name", athena_database_name,
+        "--add-validation-field", str(add_validation_field),
+        "--logs-dir", transform_logs_dir,
+    ]
+
+    # ---------
+    # INGEST configs
+    # ---------
+    lines_per_batch = config["stage"]["ingest"]["lines_per_batch"]
+    io_multiplier = config["stage"]["ingest"]["io_multiplier"]
+    retries = config["stage"]["ingest"]["retries"]
+    precision = config["stage"]["ingest"]["precision"]
+    ingest_logs_dir = os.path.join(base_logs_dir, config["stage"]["ingest"]["logs_dir"])
+    continue_on_error = config["stage"]["ingest"]["continue_on_error"]
+    skip_bucket_check = config["stage"]["ingest"]["skip_bucket_check"]
+
+    influx_args = [
+        "-w", str(num_threads),
+        "-l", str(lines_per_batch),
+        "-m", str(io_multiplier),
+        "-r", str(retries),
+        "-p", precision,
+        "--logs-dir", str(ingest_logs_dir),
+    ]
+    if continue_on_error:
+        influx_args.append("--continue-on-error")
+    if skip_bucket_check:
+        influx_args.append("--skip-bucket-check")
+
+    influxdb_url = os.environ["INFLUXDB_V2_URL"]
+    influxdb_token = os.environ["INFLUXDB_V2_TOKEN"]
+    influxdb_org = os.environ["INFLUXDB_V2_ORG"]
+
+    migration_logger.info(f"InfluxDB URL: {influxdb_url}")
+
+    # ---------
+    # VALIDATION configs
+    # ---------
+    validation_logs_dir = os.path.join(base_logs_dir, config["stage"]["validation"]["logs_dir"])
+
+    validation_common_args = [
+        "--source-engine", "timestream",
+        "--athena-output", s3_uri,
+        "--influxdb-v2-url", influxdb_url,
+        "--influxdb-v2-token", influxdb_token,
+        "--influxdb-v2-org", influxdb_org,
+        "--start-time", to_iso_z(unload_start_time),
+        "--end-time", to_iso_z(unload_end_time),
+        "--logs-dir", validation_logs_dir,
+        "--skip-wal-check",
+    ]
+
+    # ---------
+    # Setup clients and util classes
+    # ---------
+    migration_logger.info("-"*20)
+    session = Session()
+    timestream_utility = TimestreamUtility(
+        aws_region, sns_topic_arn, enable_dynamodb_logger)
+    s3_utility = S3Utility(aws_region)
+
+    # initialize bucket if not exists
+    bucket_name = s3_uri.removeprefix("s3://")
+    managed_bucket = False
+    if not s3_utility.s3_bucket_exists(bucket_name):
+        managed_bucket = True
+        migration_logger.info(f"Creating S3 bucket '{s3_uri}' to store migration artifacts")
+        s3_utility.create_s3_bucket(bucket_name)
+ 
+    # ========================
+    # gather runs for unload, transform
+    # ========================
+    unload_runs = []
+    transform_runs = []
+
+    # Migrate all databases
+    if all_databases:
+        unload_flags = ["--export-all-databases"]
+        unload_runs.append(unload_flags + unload_common_args)
+
+        # fetch all databases
+        all_databases = timestream_utility.get_all_databases()
+        db_table_map = {}
+
+        for db_name in all_databases:
+            # save database names for later
+            db_table_map[db_name] = []
+
+            transform_flags = [
+                "--database", db_name,
+                 "--all-tables",
+            ]
+            dimensions_to_fields = []
+            if db_name in dimensions_to_fields_map.keys():
+                dimensions_to_fields_db = dimensions_to_fields_map[db_name]
+                for table_name, dimensions in dimensions_to_fields_db.items():
+                    dimensions_csv = ",".join(dimensions)
+                    dimensions_to_fields.append(f"{table_name}={dimensions_csv}")
+
+            for table_dimensions in dimensions_to_fields:
+                transform_flags += [
+                    "--dimensions-to-fields", table_dimensions,
+                ]
+
+            transform_runs.append(transform_flags + transform_common_args)
+
+    # migrate specific databases/tables
+    else:
+        for db_name, tables in db_table_map.items():
+            if tables:
+                for table in tables:
+                    unload_flags = [
+                        "--database", db_name,
+                        "--table", table, "--export-table"
+                    ]
+                    unload_runs.append(unload_flags + unload_common_args)
+
+                transform_flags = [
+                    "--database", db_name,
+                    "--tables", ",".join(tables)
+                ]
+            # export full database
+            else:
+                unload_flags = [
+                    "--database", db_name,
+                    "--export-database"
+                ]
+                unload_runs.append(unload_flags + unload_common_args)
+
+                transform_flags = [
+                    "--database", db_name,
+                    "--all-tables"
+                ]
+
+            dimensions_to_fields = []
+            if db_name in dimensions_to_fields_map.keys():
+                dimensions_to_fields_db = dimensions_to_fields_map[db_name]
+                for table_name, dimensions in dimensions_to_fields_db.items():
+                    dimensions_csv = ",".join(dimensions)
+                    dimensions_to_fields.append(f"{table_name}={dimensions_csv}")
+
+            for table_dimensions in dimensions_to_fields:
+                transform_flags += [
+                    "--dimensions-to-fields", table_dimensions,
+                ]
+            transform_runs.append(transform_flags + transform_common_args)
+
+    migration_logger.info(f"UNLOAD batch size: {len(unload_runs)}")
+    migration_logger.info(f"TRANSFORM batch size: {len(transform_runs)}")
+
+    # create athena database if not exists
+    create_athena_db_if_not_exists(session, athena_database_name)
+
+    # ---------
+    # Run unloads
+    # ---------
+    migration_logger.info("Executing UNLOAD(s)")
+    execute_jobs(unload_main, unload_runs, num_threads)
+
+    # ---------
+    # Run transforms
+    # ---------
+    migration_logger.info("Executing TRANSFORM(s)")
+    execute_jobs(transform.main, transform_runs, num_threads)
+
+
+    # create directory to store LP
+    lp_base_directory = "lp_output"
+    os.makedirs(lp_base_directory, exist_ok=True)
+
+    client = InfluxDBClient.from_env_properties()
+    validation_logs_dir = os.path.join(base_logs_dir, config["stage"]["validation"]["logs_dir"])
+    for db_name, tables in db_table_map.items():
+        lp_directory = f"{lp_base_directory}/{db_name}"
+        if not tables:
+            tables = timestream_utility.get_all_tables(db_name)
+            db_table_map[db_name] = tables
+
+        # Sync from s3
+        for table in tables:
+            migration_logger.info(f"Downloading LP for table '{table}' from database '{db_name}'...")
+            os.makedirs(lp_directory, exist_ok=True)
+            s3_utility.sync_line_protocol_to_storage(
+                s3_bucket_path=s3_uri,
+                directory=lp_directory,
+                timestream_database_name=db_name,
+                timestream_table_name=table,
+            )
+        try:
+            # ---------
+            # Run ingestion & validation
+            # ---------
+            # Create bucket if not exists
+            if not skip_bucket_check:
+                migration_logger.info(f"Checking if bucket: '{db_name}' exists")
+                buckets = client.buckets_api().find_buckets().buckets
+                if not any(bucket.name == db_name for bucket in buckets):
+                    client.buckets_api().create_bucket(bucket_name=db_name)
+                    migration_logger.info(f"Bucket '{db_name}' created.")
+
+            migration_logger.info(f"Begin ingestion to '{db_name}' from {lp_directory}")
+            influxdb_ingestion.main(influx_args + [db_name, lp_directory])
+
+            migration_logger.info("Ingestion complete.")
+
+            # make room by clearing LP
+            if os.path.exists(lp_directory):
+                shutil.rmtree(lp_directory)
+                migration_logger.info(f"Deleted {lp_directory}")
+        except Exception as e:
+            migration_logger.error(f"Error during ingestion: {e}")
+
+        # TODO: add v3 support in validation
+        if not skip_bucket_check:
+            migration_logger.info(f"Executing validation(s) for {db_name}")
+            for table in tables:
+                validation_args = validation_common_args + [
+                    "--timestream-database-name",
+                    db_name,
+                    "--timestream-table-name",
+                    table,
+                    "--influxdb-v2-bucket",
+                    db_name,
+                    "--influxdb-v2-measurement",
+                    table,
+                ]
+                if db_name in dimensions_to_fields_map.keys():
+                    dims = timestream_utility.list_dimension_columns(db_name, table)
+                    for table_name, dimensions in dimensions_to_fields_map[db_name].items():
+                        if table_name == table:
+                            schema_tags = [dim for dim in dims if dim not in dimensions]
+                            tags = validator.get_quoted_tags(schema_tags)
+                            validation_args += [
+
+                                "--schema-tags", tags
+                            ]
+                validator.main(validation_args)
+
+    migration_logger.info("Validation complete.")
+    # ---------
+    # Perform clean up
+    # ---------
+    migration_logger.info("-"*20)
+    migration_logger.info("Performing cleanup")
+    if client:
+        client.close()
+
+    # Delete LP directory
+    try:
+        if os.path.exists(lp_base_directory):
+            shutil.rmtree(lp_base_directory)
+            migration_logger.info(f"Deleted {lp_base_directory}")
+    except Exception as e:
+        migration_logger.error(f"Error deleting {lp_base_directory}: {e}")
+
+    # Delete Athena tables
+    glue_client = session.client("glue")
+    try:
+        for db_name, tables in db_table_map.items():
+            if tables:
+                cleanup_athena(
+                    glue=glue_client,
+                    athena_database="default",
+                    timestream_database=db_name,
+                    timestream_tables=tables,
+                )
+            # no tables = all tables; clean all tables
+            else:
+                all_tables = timestream_utility.get_all_tables(db_name)
+                cleanup_athena(
+                    glue=glue_client,
+                    athena_database="default",
+                    timestream_database=db_name,
+                    timestream_tables=all_tables,
+                )
+        migration_logger.info(f"Deleted athena tables for {db_name}")
+
+    except Exception as e:
+        migration_logger.error(f"Error deleting Athena tables: {e}")
+    finally:
+        glue_client.close()
+
+    # Delete managed S3 bucket if exists
+    try:
+        if managed_bucket:
+            s3_utility.delete_bucket_and_contents(bucket_name)
+            migration_logger.info(f"Deleted bucket: {bucket_name}")
+    except Exception as e:
+        migration_logger.error(f"Error deleting {bucket_name}: {e}")
+
+    return
+
+if __name__ == "__main__":
+    main()

--- a/tools/python/liveanalytics_migration_scripts/targets/timestream_for_influxdb/transform/transform.py
+++ b/tools/python/liveanalytics_migration_scripts/targets/timestream_for_influxdb/transform/transform.py
@@ -1,5 +1,7 @@
 import argparse
 from dataclasses import dataclass
+import logging
+import time
 import os
 import sys
 import pyarrow.parquet as pq
@@ -12,11 +14,10 @@ sys.path.insert(
 from unload.utils.timestream_utils import TimestreamUtility
 from unload.utils.s3_utils import S3Utility
 from unload.utils.athena_utils import AthenaUtility, MAX_WAIT_SECONDS
-from unload.utils.logger_utils import create_logger
+from unload.utils.logger_utils import update_logger
 
 
-transform_logger = create_logger("transform")
-
+transform_logger = logging.getLogger("transform")
 
 @dataclass
 class LineProtocolTranslationResult:
@@ -728,8 +729,17 @@ def main(input_args):
         required=True,
         type=parse_bool_cli_argument,
     )
+    parser.add_argument(
+        "--logs-dir",
+        help="Directory for export logs .",
+        default="transform-logs",
+        required=False
+    )
 
     args = parser.parse_args(input_args)
+
+    log_file_name = f'transform_{time.strftime("%Y%m%d_%H%M%S")}.log'
+    update_logger(transform_logger, args.logs_dir, log_file_name)
 
     timestream_database_name = args.database_name
     s3_bucket_path = args.s3_bucket_path.rstrip("/")

--- a/tools/python/liveanalytics_migration_scripts/targets/timestream_for_influxdb/validation/validator.py
+++ b/tools/python/liveanalytics_migration_scripts/targets/timestream_for_influxdb/validation/validator.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 import argparse
 from io import StringIO
 import os
+import logging
 import sys
 import time
 import datetime as dt
@@ -38,10 +39,38 @@ import requests
 from dotenv import load_dotenv
 import boto3
 import influxdb_client
+from unload.utils.logger_utils import update_logger
+
+validation_logger = logging.getLogger("validation")
 
 
 # ───────────────────────── Helpers ──────────────────────────
 
+def get_quoted_tags(dimensions: list) -> str:
+    """
+    Produces line protocol tags in a format that the validation script
+    expects for its --schema-tags argument. To do this, this function
+    builds a string comprised of comma-separated dimension names, adding
+    quotes to any dimension name that includes commas.
+
+    Args:
+        dimensions (list[dict]): A list of dimensions where each dimension
+            can be a dict with the key "Name".
+
+    Returns:
+        str
+    """
+    # measure_name is assumed to always be present as a tag.
+    quoted_tags = ["measure_name"]
+    for dimension in dimensions:
+        if isinstance(dimension, dict):
+            dimension = dimension["Name"]
+
+        if "," in dimension:
+            quoted_tags.append(f'"{dimension}"')
+        else:
+            quoted_tags.append(dimension)
+    return ",".join(quoted_tags)
 
 def timed(func: Callable[..., Any], *args: Any, **kwargs: Any) -> Tuple[Any, float]:
     """Execute *func* and measure its runtime."""
@@ -128,7 +157,7 @@ def count_timestream_rows(
     rows: list[dict] = []
     next_token: str | None = None
 
-    print(f"--- Timestream ---\n\nRunning query:\n{query}\n")
+    validation_logger.info(f"--- Timestream ---\n\nRunning query:\n{query}\n")
     while True:
         params: Dict[str, str] = {"QueryString": query}
         if next_token:
@@ -145,7 +174,7 @@ def count_timestream_rows(
 
     total = int(rows[0]["Data"][0]["ScalarValue"])
     label = f"{database}.{table} ({start_time or 'begin'} - {end_time or 'now'})"
-    print(f"[TIMESTREAM] Total records in {label}: {total}\n")
+    validation_logger.info(f"[TIMESTREAM] Total records in {label}: {total}\n")
     return total
 
 
@@ -202,7 +231,7 @@ def count_athena_rows(
 
     client = session.client("athena")
 
-    print(f"--- Athena ---\n\nRunning query:\n{query}\n")
+    validation_logger.info(f"--- Athena ---\n\nRunning query:\n{query}\n")
     execution = client.start_query_execution(
         QueryString=query,
         QueryExecutionContext={"Database": database},
@@ -229,7 +258,7 @@ def count_athena_rows(
     rows = client.get_query_results(QueryExecutionId=qid)["ResultSet"]["Rows"]
     count = int(rows[1]["Data"][0]["VarCharValue"])
     label = f"{database}.{table} ({start_time or 'begin'} - {end_time or 'now'})"
-    print(f"[ATHENA] Total records in {label}: {count}\n")
+    validation_logger.info(f"[ATHENA] Total records in {label}: {count}\n")
     return count
 
 
@@ -286,12 +315,12 @@ def count_influx_rows(
             f' |> filter(fn: (r) => r._field == "{row_identifier}")'
             " |> group() |> count()"
         )
-        print(f"--- InfluxDB ---\n\nRunning query:\n{query}\n")
+        validation_logger.info(f"--- InfluxDB ---\n\nRunning query:\n{query}\n")
         tables = client.query_api().query(org=org, query=query)
 
     total = sum(int(rec.get_value()) for tbl in tables for rec in tbl.records)
     label = f"{bucket}.{measurement} ({start_time or 'begin'} - {end_time or 'now'})"
-    print(f"[INFLUXDB] Total LP points in {label}: {total}\n")
+    validation_logger.info(f"[INFLUXDB] Total LP points in {label}: {total}\n")
     return total
 
 
@@ -432,6 +461,12 @@ def parse_args(input_args: list[str]) -> argparse.Namespace:
         help="Skip querying the source engine (Athena/Timestream) and only "
         "return the InfluxDB row count.",
     )
+    parser.add_argument(
+        "--logs-dir",
+        help="Directory for export logs .",
+        default="transform-logs",
+        required=False
+    )
 
     args = parser.parse_args(remaining, namespace=prelim)
     return args
@@ -442,15 +477,19 @@ def parse_args(input_args: list[str]) -> argparse.Namespace:
 
 def main(input_args) -> None:
     args = parse_args(input_args)
-    print("-" * 20)
-    print("Starting validation")
-    print("-" * 20)
+
+    log_file_name = f'validation_{time.strftime("%Y%m%d_%H%M%S")}.log'
+    update_logger(validation_logger, args.logs_dir, log_file_name)
+
+    validation_logger.info("-" * 20)
+    validation_logger.info("Starting validation")
+    validation_logger.info("-" * 20)
 
     poll_interval = int(args.poll_metrics_interval)
     session = requests.Session()
 
     if not args.skip_wal_check:
-        print(
+        validation_logger.info(
             f"\nPolling {args.influxdb_v2_url}/metrics to wait for WAL to complete flushing ...\n"
         )
         while True:
@@ -458,23 +497,23 @@ def main(input_args) -> None:
             try:
                 nz_wals = poll_metrics(session=session, url=args.influxdb_v2_url)
             except requests.RequestException as exc:
-                print(
+                validation_logger.error(
                     f"{timestamp}  request failed ({exc}); retrying in {poll_interval}s"
                 )
                 time.sleep(poll_interval)
                 continue
 
             if nz_wals:
-                print(
+                validation_logger.info(
                     f"{timestamp}  {len(nz_wals):>2} shards with non-zero WAL "
                     f"(largest={max(nz_wals) / 1024:,.1f} KiB)"
                 )
                 time.sleep(poll_interval)
             else:
-                print(f"{timestamp}  WAL empty on all shards — ready for validation.\n")
+                validation_logger.info(f"{timestamp}  WAL empty on all shards — ready for validation.\n")
                 break
     else:
-        print("\nSkipping check for InfluxDB WAL to complete flushing ...\n")
+        validation_logger.info("\nSkipping check for InfluxDB WAL to complete flushing ...\n")
 
     if args.schema_tags:
         reader = csv.reader(StringIO(args.schema_tags))
@@ -484,7 +523,7 @@ def main(input_args) -> None:
 
     boto3_session = initialize_session()
 
-    print("Starting validation ...\n")
+    validation_logger.info("Starting validation ...\n")
 
     futures: Dict[str, Any] = {}
     results: Dict[str, Tuple[Any, float]] = {}
@@ -539,37 +578,36 @@ def main(input_args) -> None:
     src_count, src_elapsed = results.get("Source Engine", (None, None))
 
     if infl_count is None:
-        print("\n❌ InfluxDB query failed - cannot continue comparison.")
+        validation_logger.error("\n❌ InfluxDB query failed - cannot continue comparison.")
     elif infl_count == 0:
-        print(f"\n❗ InfluxDB returned 0 points in {args.influxdb_v2_bucket}.")
-        sys.exit(1)
+        validation_logger.info(f"\n❗ InfluxDB returned 0 points in {args.influxdb_v2_bucket}.")
+        return
 
     if infl_count is not None and args.influx_only:
-        print(f"\n⏱ InfluxDB query time: {infl_elapsed:.2f}s")
-        print("\n--------- Influx-Only Results ---------\n")
-        print(f"InfluxDB row count: {infl_count}\n")
+        validation_logger.info(f"\n⏱ InfluxDB query time: {infl_elapsed:.2f}s")
+        validation_logger.info("\n--------- Influx-Only Results ---------\n")
+        validation_logger.info(f"InfluxDB row count: {infl_count}\n")
 
     if not errors:
-        print("--------- Migration Results ---------\n")
+        validation_logger.info("--------- Migration Results ---------\n")
         if src_elapsed is not None:
             src_label = args.source_engine.title()
-            print(f"⏱ {src_label} query time: {src_elapsed:.2f}s")
+            validation_logger.info(f"⏱ {src_label} query time: {src_elapsed:.2f}s")
         if infl_elapsed is not None:
-            print(f"⏱ InfluxDB query time:   {infl_elapsed:.2f}s\n")
+            validation_logger.info(f"⏱ InfluxDB query time:   {infl_elapsed:.2f}s\n")
 
         if src_count is not None and infl_count is not None:
             if src_count == infl_count:
-                print(f"🎉  {src_label} and InfluxDB row counts match.\n")
+                validation_logger.info(f"🎉  {src_label} and InfluxDB row counts match.\n")
             else:
                 sign = ">" if src_count > infl_count else "<"
-                print(f"⚠️  {src_label} ({src_count}) {sign} InfluxDB ({infl_count})\n")
-                sys.exit(1)
+                validation_logger.info(f"⚠️  {src_label} ({src_count}) {sign} InfluxDB ({infl_count})\n")
+                return
     else:
-        print("\n--------- Exceptions ---------\n")
+        validation_logger.info("\n--------- Exceptions ---------\n")
         for name, exc in errors.items():
-            print(f"{name} query failed: {exc}")
-        print()
-        sys.exit(1)
+            validation_logger.error(f"{name} query failed: {exc}")
+        return
 
 
 if __name__ == "__main__":

--- a/tools/python/liveanalytics_migration_scripts/tests/integration/test_influxdb_v2_target.py
+++ b/tools/python/liveanalytics_migration_scripts/tests/integration/test_influxdb_v2_target.py
@@ -211,31 +211,6 @@ class InfluxDbV2TargetTestCase(BaseIntegrationTestCase):
             if not self.silence_cleanup_logging:
                 logging.warning(f"tearDown: Failed to delete InfluxDB bucket: {e}")
 
-    @staticmethod
-    def get_quoted_tags(dimensions: list) -> str:
-        """
-        Produces line protocol tags in a format that the validation script
-        expects for its --schema-tags argument. To do this, this function
-        builds a string comprised of comma-separated dimension names, adding
-        quotes to any dimension name that includes commas.
-
-        Args:
-            dimensions (list[dict]): A list of dimensions where each dimension
-                is a dict with the key "Name".
-
-        Returns:
-            str
-        """
-        # measure_name is assumed to always be present as a tag.
-        quoted_tags = ["measure_name"]
-        for dimension in dimensions:
-            tag = dimension["Name"]
-            if "," in tag:
-                quoted_tags.append(f'"{tag}"')
-            else:
-                quoted_tags.append(tag)
-        return ",".join(quoted_tags)
-
     def test_single_measure_basic(self):
         current_time = pandas.Timestamp.now()
 
@@ -258,7 +233,7 @@ class InfluxDbV2TargetTestCase(BaseIntegrationTestCase):
             "TimeUnit": "NANOSECONDS",
         }
 
-        schema_tags = self.get_quoted_tags(dimensions)
+        schema_tags = validator.get_quoted_tags(dimensions)
 
         self.put_records([record])
 
@@ -359,7 +334,7 @@ class InfluxDbV2TargetTestCase(BaseIntegrationTestCase):
             "TimeUnit": "NANOSECONDS",
         }
 
-        schema_tags = self.get_quoted_tags(dimensions)
+        schema_tags = validator.get_quoted_tags(dimensions)
 
         self.put_records([record])
         unload.main(
@@ -581,7 +556,7 @@ class InfluxDbV2TargetTestCase(BaseIntegrationTestCase):
             ],
         }
 
-        schema_tags = self.get_quoted_tags(dimensions)
+        schema_tags = validator.get_quoted_tags(dimensions)
 
         self.put_records([record])
         unload.main(
@@ -686,7 +661,7 @@ class InfluxDbV2TargetTestCase(BaseIntegrationTestCase):
             ],
         }
 
-        schema_tags = self.get_quoted_tags(dimensions)
+        schema_tags = validator.get_quoted_tags(dimensions)
 
         self.put_records([record])
         unload.main(
@@ -841,7 +816,7 @@ class InfluxDbV2TargetTestCase(BaseIntegrationTestCase):
             },
         ]
 
-        schema_tags = self.get_quoted_tags(dimensions)
+        schema_tags = validator.get_quoted_tags(dimensions)
 
         self.put_records(records)
         unload.main(
@@ -973,7 +948,7 @@ class InfluxDbV2TargetTestCase(BaseIntegrationTestCase):
             },
         ]
 
-        schema_tags = self.get_quoted_tags(dimensions)
+        schema_tags = validator.get_quoted_tags(dimensions)
 
         self.put_records(records)
         unload.main(

--- a/tools/python/liveanalytics_migration_scripts/tests/test-requirements.txt
+++ b/tools/python/liveanalytics_migration_scripts/tests/test-requirements.txt
@@ -1,4 +1,3 @@
 -r ../requirements.txt
-pandas==2.2.3
 pytest==7.4.0
 testcontainers==4.10.0

--- a/tools/python/liveanalytics_migration_scripts/unload/utils/logger_utils.py
+++ b/tools/python/liveanalytics_migration_scripts/unload/utils/logger_utils.py
@@ -22,7 +22,7 @@ def create_logger(logger_name, log_file=None, log_level=logging.INFO):
         logger.handlers.clear()
     
     # Create formatter
-    formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - %(message)s')
+    formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - [Thread-%(thread)d] - %(message)s')
     
     # Create console handler and set level
     ch = logging.StreamHandler()
@@ -35,7 +35,7 @@ def create_logger(logger_name, log_file=None, log_level=logging.INFO):
         # Create directory for log file if it doesn't exist
         log_dir = os.path.dirname(log_file)
         if log_dir and not os.path.exists(log_dir):
-            os.makedirs(log_dir)
+            os.makedirs(log_dir, exist_ok=True)
             
         # Create file handler and set level
         fh = logging.FileHandler(log_file)
@@ -44,3 +44,25 @@ def create_logger(logger_name, log_file=None, log_level=logging.INFO):
         logger.addHandler(fh)
     
     return logger
+
+
+def update_logger(logger, log_dir="logs", log_file_name=None, log_level=logging.INFO):
+    os.makedirs(log_dir, exist_ok=True)
+    logger.setLevel(log_level)
+
+    # Clear any existing handlers (to avoid duplicate logs)
+    if logger.handlers:
+        logger.handlers.clear()
+
+    formatter = logging.Formatter('%(asctime)s - %(name)s - %(levelname)s - [Thread-%(thread)d] - %(message)s')
+
+    ch = logging.StreamHandler()
+    ch.setLevel(log_level)
+    ch.setFormatter(formatter)
+    logger.addHandler(ch)
+
+    log_file_path = os.path.join(log_dir, log_file_name)
+    fh = logging.FileHandler(log_file_path)
+    fh.setLevel(log_level)
+    fh.setFormatter(formatter)
+    logger.addHandler(fh)

--- a/tools/python/liveanalytics_migration_scripts/unload/utils/s3_utils.py
+++ b/tools/python/liveanalytics_migration_scripts/unload/utils/s3_utils.py
@@ -348,3 +348,62 @@ class S3Utility:
                 local_file_path = os.path.join(directory, rel_path)
                 os.makedirs(os.path.dirname(local_file_path), exist_ok=True)
                 self.s3_client.download_file(s3_bucket_name, s3_key, local_file_path)
+
+    def delete_bucket_and_contents(self, bucket_name: str, batch_size: int = 1000):
+        """
+        Deletes every object (and its versions if versioning is enabled) inside the
+        bucket referenced by *bucket_name* and then deletes the bucket itself.
+
+        Args:
+            bucket_name (str): The S3 bucket name.
+            batch_size (int): The number of objects to delete per ``delete_objects`` call.
+                              The AWS API supports a maximum of 1000 per request.
+
+        Raises:
+            RuntimeError: If the bucket does not exist or deletion fails.
+        """
+        if not self.s3_bucket_exists(bucket_name):
+            raise RuntimeError(f"Bucket {bucket_name} does not exist")
+
+        self.logger.info(f"Deleting all objects from bucket '{bucket_name}'")
+
+        # Delete object versions (handles versioned buckets) as well as
+        # any delete markers.
+        paginator = self.s3_client.get_paginator("list_object_versions")
+        delete_batch = []
+        for page in paginator.paginate(Bucket=bucket_name):
+            for version in page.get("Versions", []) + page.get("DeleteMarkers", []):
+                delete_batch.append(
+                    {"Key": version["Key"], "VersionId": version["VersionId"]}
+                )
+                if len(delete_batch) == batch_size:
+                    self.s3_client.delete_objects(
+                        Bucket=bucket_name, Delete={"Objects": delete_batch}
+                    )
+                    delete_batch.clear()
+
+            # Flush remaining items in batch at end of page
+            if delete_batch:
+                self.s3_client.delete_objects(
+                    Bucket=bucket_name, Delete={"Objects": delete_batch}
+                )
+                delete_batch.clear()
+
+        # For non-versioned buckets or if version listing was empty, ensure
+        # current objects are also removed.
+        paginator = self.s3_client.get_paginator("list_objects_v2")
+        for page in paginator.paginate(Bucket=bucket_name):
+            objects = [{"Key": obj["Key"]} for obj in page.get("Contents", [])]
+            if objects:
+                # Batch in chunks of batch_size
+                for i in range(0, len(objects), batch_size):
+                    self.s3_client.delete_objects(
+                        Bucket=bucket_name,
+                        Delete={"Objects": objects[i : i + batch_size]},
+                    )
+
+        self.logger.info(f"Deleting bucket '{bucket_name}'")
+        self.s3_client.delete_bucket(Bucket=bucket_name)
+        self.logger.info(
+            f"Bucket '{bucket_name}' and all of its contents were deleted successfully"
+        )

--- a/tools/python/liveanalytics_migration_scripts/unload/utils/timestream_utils.py
+++ b/tools/python/liveanalytics_migration_scripts/unload/utils/timestream_utils.py
@@ -154,7 +154,7 @@ class TimestreamUtility:
 
         while current < end_time:
             # You cannot have more than 100 partitions for single unload.
-            partition_count = custom_partition_count 
+            partition_count = int(custom_partition_count)
             if partition_by == 'hour':
                 next_time = current + timedelta(hours=partition_count)
             if partition_by == "day":
@@ -703,4 +703,35 @@ class TimestreamUtility:
             return timestamp_columns
         except Exception as e:
             self.logger.error(f"Failed to list timestamp columns for {database}.{table}: {str(e)}", exc_info=True)
+            raise
+
+    def list_dimension_columns(self, database: str, table: str):
+        """
+        Retrieves all columns of type DIMENSION from the specified Timestream table.
+
+        Args:
+            database (str): The name of the Timestream database.
+            table (str): The name of the Timestream table.
+
+        Returns:
+            List[str]: A list of column names that are classified as DIMENSION columns.
+
+        Raises:
+            Exception: If the Timestream query fails or an unexpected error occurs during processing.
+        """
+        query_string = f'DESCRIBE "{database}"."{table}"'
+        try:
+            resp = self.timestream_read_client.query(QueryString=query_string)
+            rows = resp.get("Rows", [])
+            return [
+                r["Data"][0]["ScalarValue"]
+                for r in rows
+                if len(r["Data"]) > 2
+                and r["Data"][2].get("ScalarValue", "").upper() == "DIMENSION"
+            ]
+        except Exception as exc:
+            self.logger.error(
+                f"Failed to list dimension columns for {database}.{table}: {exc}",
+                exc_info=True,
+            )
             raise


### PR DESCRIPTION
*Issue #, if available:*

N/A.

*Description of changes:*

This PR adds an end-to-end migration script for InfluxDB.

0. To run an end-to-end migration to InfluxDB, first define the following environment variables:

```
export INFLUXDB_V2_URL="https://l75mpzejl3-zcipc7m4j2l72o.timestream-influxdb.us-west-2.on.aws:8086"
export INFLUXDB_V2_ORG="org"
export INFLUXDB_V2_TOKEN="xxx"
```

For migrations to InfluxDB v3, set `skip_bucket_check` to `true` in `config.yaml` and omit the `INFLUXDB_V2_ORG` environment variable

```
export INFLUXDB_V2_URL="https://m1xovyvziu-izdmnhd7injid2.timestream-influxdb-alpha.us-west-2.on.aws:8181"
export INFLUXDB_V2_TOKEN="xxx"
```
(vars are defined at line 200 in `migrate.py` for convenience)


1. Run the migration script with

```
python influxdb_migration.py 
```


Here are the resulting log files created in the `migration-logs` directory for a run with two DBs

```
migration-logs/
├── ingestion-logs
│   ├── ingestion_20250626_104709.log
│   ├── ingestion_20250626_104715.log
│   ├── tracking_20250626_104710
│   │   └── ingested_files.txt
│   ├── tracking_20250626_104715
│   │   └── ingested_files.txt
│   ├── worker-9792.log
│   ├── worker-9793.log
│   └── worker-9802.log
├── migration_20250626_174629.log
├── transform-logs
│   └── transform_20250626_104634.log
├── unload-logs
│   └── timestream_export_20250626_104630.log
└── validation-logs
    ├── validation_20250626_104712.log
    ├── validation_20250626_104713.log
    └── validation_20250626_104719.log
```

2. Some useful influx v3 curl commands for testing:

list databases:

```
curl -G "https://m1xovyvziu-izdmnhd7injid2.timestream-influxdb-alpha.us-west-2.on.aws:8181/api/v3/configure/database?format=json" \
  --header "Authorization: Bearer xxx" 
```

delete database:
```
curl -X DELETE "https://m1xovyvziu-izdmnhd7injid2.timestream-influxdb-alpha.us-west-2.on.aws:8181/api/v3/configure/database" \
  -H "Authorization: Bearer xxx" \
  -G \
  --data-urlencode "db=buk3"
```

count unique rows from db/table:
```
curl -G "https://m1xovyvziu-izdmnhd7injid2.timestream-influxdb-alpha.us-west-2.on.aws:8181/query"   --header "Authorization: Bearer xxx"   --data-urlencode "db=benchmark8"   --data-urlencode 'q=SELECT count(la_unload) FROM cpu'
```

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
