### PR TITLE
Upgrade AWS provider to 6.10 and add region variable

### DIFF
--- a/integrations/terraform/ec2-private-influxdb/README.md
+++ b/integrations/terraform/ec2-private-influxdb/README.md
@@ -39,7 +39,7 @@ The EC2 instance deployed by this sample is referred to as a "bastion host," mea
 
 ### Tags
 
-[Tagging AWS resources](https://aws.amazon.com/solutions/guidance/tagging-on-aws/) is useful. To tag all resources, define `default_tags` in the `aws` provider block, at the top of [`main.tf`](./main.tf):
+[Tagging AWS resources](https://aws.amazon.com/solutions/guidance/tagging-on-aws/) is useful. To tag all resources, define `default_tags` in an `aws` provider block, in [`main.tf`](./main.tf):
 
 ```terraform
 provider "aws" {

--- a/integrations/terraform/ec2-private-influxdb/main.tf
+++ b/integrations/terraform/ec2-private-influxdb/main.tf
@@ -3,17 +3,14 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.96.0"
+      version = "~> 6.10.0"
     }
   }
 }
 
-provider "aws" {
-  region = "us-west-2"
-}
-
 resource "aws_vpc" "vpc" {
   cidr_block = "10.0.0.0/16"
+  region = var.region
 }
 
 # Private subnet used by the Timestream for InfluxDB instance.
@@ -21,6 +18,7 @@ resource "aws_subnet" "private_subnet" {
   vpc_id                  = aws_vpc.vpc.id
   cidr_block              = "10.0.1.0/24"
   map_public_ip_on_launch = false
+  region = var.region
 }
 
 # Public subnet used by the EC2 bastion host.
@@ -28,21 +26,25 @@ resource "aws_subnet" "public_subnet" {
   vpc_id                  = aws_vpc.vpc.id
   cidr_block              = "10.0.2.0/24"
   map_public_ip_on_launch = true
+  region = var.region
 }
 
 resource "aws_internet_gateway" "internet_gateway" {
   vpc_id = aws_vpc.vpc.id
+  region = var.region
 }
 
 resource "aws_route" "test_route" {
   route_table_id         = aws_vpc.vpc.main_route_table_id
   destination_cidr_block = "0.0.0.0/0"
   gateway_id             = aws_internet_gateway.internet_gateway.id
+  region = var.region
 }
 
 resource "aws_route_table_association" "route_table_association" {
   subnet_id      = aws_subnet.public_subnet.id
   route_table_id = aws_vpc.vpc.main_route_table_id
+  region = var.region
 }
 
 resource "aws_security_group" "ec2_security_group" {
@@ -64,6 +66,7 @@ resource "aws_security_group" "ec2_security_group" {
     protocol    = "-1"
     cidr_blocks = ["0.0.0.0/0"]
   }
+  region = var.region
 }
 
 resource "aws_security_group" "timestream_influxdb_security_group" {
@@ -78,6 +81,7 @@ resource "aws_security_group" "timestream_influxdb_security_group" {
     protocol        = "tcp"
     security_groups = [aws_security_group.ec2_security_group.id]
   }
+  region = var.region
 }
 
 data "aws_ami" "amzn-linux-2023-ami" {
@@ -88,6 +92,7 @@ data "aws_ami" "amzn-linux-2023-ami" {
     name   = "name"
     values = ["al2023-ami-2023.*-arm64"]
   }
+  region = var.region
 }
 
 resource "aws_instance" "ec2_instance" {
@@ -109,6 +114,7 @@ resource "aws_instance" "ec2_instance" {
   tags = {
     Name = var.ec2_instance_name
   }
+  region = var.region
 }
 
 resource "aws_timestreaminfluxdb_db_instance" "timestream_influxdb_instance" {
@@ -123,6 +129,7 @@ resource "aws_timestreaminfluxdb_db_instance" "timestream_influxdb_instance" {
   port                   = 8086
   organization           = "organization"
   publicly_accessible    = false
+  region = var.region
 }
 
 output "instance_url" {

--- a/integrations/terraform/ec2-private-influxdb/main.tf
+++ b/integrations/terraform/ec2-private-influxdb/main.tf
@@ -10,7 +10,7 @@ terraform {
 
 resource "aws_vpc" "vpc" {
   cidr_block = "10.0.0.0/16"
-  region = var.region
+  region     = var.region
 }
 
 # Private subnet used by the Timestream for InfluxDB instance.
@@ -18,7 +18,7 @@ resource "aws_subnet" "private_subnet" {
   vpc_id                  = aws_vpc.vpc.id
   cidr_block              = "10.0.1.0/24"
   map_public_ip_on_launch = false
-  region = var.region
+  region                  = var.region
 }
 
 # Public subnet used by the EC2 bastion host.
@@ -26,7 +26,7 @@ resource "aws_subnet" "public_subnet" {
   vpc_id                  = aws_vpc.vpc.id
   cidr_block              = "10.0.2.0/24"
   map_public_ip_on_launch = true
-  region = var.region
+  region                  = var.region
 }
 
 resource "aws_internet_gateway" "internet_gateway" {
@@ -38,13 +38,13 @@ resource "aws_route" "test_route" {
   route_table_id         = aws_vpc.vpc.main_route_table_id
   destination_cidr_block = "0.0.0.0/0"
   gateway_id             = aws_internet_gateway.internet_gateway.id
-  region = var.region
+  region                 = var.region
 }
 
 resource "aws_route_table_association" "route_table_association" {
   subnet_id      = aws_subnet.public_subnet.id
   route_table_id = aws_vpc.vpc.main_route_table_id
-  region = var.region
+  region         = var.region
 }
 
 resource "aws_security_group" "ec2_security_group" {
@@ -129,7 +129,7 @@ resource "aws_timestreaminfluxdb_db_instance" "timestream_influxdb_instance" {
   port                   = 8086
   organization           = "organization"
   publicly_accessible    = false
-  region = var.region
+  region                 = var.region
 }
 
 output "instance_url" {

--- a/integrations/terraform/ec2-private-influxdb/variables.tf
+++ b/integrations/terraform/ec2-private-influxdb/variables.tf
@@ -1,3 +1,8 @@
+variable "region" {
+  type = string
+  default = "us-west-2"
+}
+
 variable "username" {
   type    = string
   default = "admin"

--- a/integrations/terraform/ec2-private-influxdb/variables.tf
+++ b/integrations/terraform/ec2-private-influxdb/variables.tf
@@ -1,6 +1,6 @@
 variable "region" {
-  type = string
-  default = "us-west-2"
+  type    = string
+  default = "us-east-1"
 }
 
 variable "username" {


### PR DESCRIPTION
*Issue #, if available:*

N/A.

*Description of changes:*

With version `6.0.0` of the AWS provider for Terraform, most resources are region aware and have a `region` argument. To support this easier way of managing regions:
- A `region` variable has been added that is used by all resources. If this variable is changed, all resources will be destroyed and recreated in the new region.
- The AWS provider for Terraform has been updated to version `6.10.0`, which includes the above-mentioned region aware functionality and also fixes for the Timestream for InfluxDB DB instance resource.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
