### PR TITLE
ci: scope down GitHub Token permissions

### DIFF
--- a/.github/workflows/influx-migration-tests-linux.yml
+++ b/.github/workflows/influx-migration-tests-linux.yml
@@ -22,6 +22,9 @@ defaults:
     shell: bash
     working-directory: 'tools/python/influx-migration'
 
+permissions:
+  contents: read
+
 jobs:
   linux64:
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [ mainline ]
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Scope Down GitHub Token Permissions

This PR updates GitHub Actions workflows to use minimal required permissions instead of the default elevated permissions.

### Why This Matters

Following the principle of least privilege, workflows should only have the specific permissions they need to function.

### Changes

This PR adds explicit `permissions:` blocks to workflows that currently rely on default permissions, scoping them down to only what's required for their operations.

Please review the changes to ensure the specified permissions match your workflow requirements.