### PR TITLE
LiveAnalytics to InfluxDB migration scripts - Handle nested quotes during transform

### DIFF
--- a/tools/python/liveanalytics_migration_scripts/requirements.txt
+++ b/tools/python/liveanalytics_migration_scripts/requirements.txt
@@ -2,7 +2,7 @@ boto3==1.38.23
 influxdb-client==1.48.0
 python-dotenv==1.1.0
 requests==2.32.4
-psycopg2-binary==2.9.10
-pyarrow==20.0.0
+psycopg2-binary==2.9.11
+pyarrow==22.0.0
 pyyaml==6.0.2
 pandas==2.2.3

--- a/tools/python/liveanalytics_migration_scripts/targets/timestream_for_influxdb/transform/transform.py
+++ b/tools/python/liveanalytics_migration_scripts/targets/timestream_for_influxdb/transform/transform.py
@@ -595,7 +595,11 @@ def translate_athena_table_to_line_protocol(
                 delimiter = ")) ||"
             if measure_value_type == "varchar":
                 lp_translation_query += f"""
-                CASE WHEN \"{measure_value_name}\" IS NOT NULL THEN REGEXP_REPLACE('{measure_value_name}', '([, =])', '\\\\$1') || '="' || CAST(\"{measure_value_name}\" AS VARCHAR) || '",' ELSE '' END {delimiter}
+                CASE WHEN \"{measure_value_name}\" IS NOT NULL
+                THEN REGEXP_REPLACE('{measure_value_name}', '([, =])', '\\\\$1') || '="' || 
+                     REGEXP_REPLACE(REGEXP_REPLACE(CAST(\"{measure_value_name}\" AS VARCHAR), '\\\\', '\\\\\\\\'), '"', '\\\\"') || '",'
+                ELSE ''
+                END {delimiter}
                 """
             elif measure_value_type == "bigint":
                 lp_translation_query += f"""

--- a/tools/python/liveanalytics_migration_scripts/tests/integration/test_influxdb_v2_target.py
+++ b/tools/python/liveanalytics_migration_scripts/tests/integration/test_influxdb_v2_target.py
@@ -937,6 +937,20 @@ class InfluxDbV2TargetTestCase(BaseIntegrationTestCase):
                     },
                 ],
             },
+            {
+                "Dimensions": dimensions,
+                "MeasureName": "multiple_back_slashes_measure_name",
+                "MeasureValueType": "MULTI",
+                "Time": str(start_time.value),
+                "TimeUnit": "NANOSECONDS",
+                "MeasureValues": [
+                    {
+                        "Name": "multiple_back_slashes_measure_value_name",
+                        "Value": "multiple\\backslashes\\\\in\\\\\\measure\\\\\\\\value",
+                        "Type": "VARCHAR",
+                    },
+                ],
+            },
         ]
 
         schema_tags = validator.get_quoted_tags(dimensions)

--- a/tools/python/liveanalytics_migration_scripts/tests/integration/test_influxdb_v2_target.py
+++ b/tools/python/liveanalytics_migration_scripts/tests/integration/test_influxdb_v2_target.py
@@ -739,6 +739,109 @@ class InfluxDbV2TargetTestCase(BaseIntegrationTestCase):
             ]
         )
 
+    def test_multi_measure_object(self):
+        current_time = pandas.Timestamp.now()
+
+        start_time = current_time - Timedelta(days=30)
+        assert isinstance(start_time, pandas.Timestamp)
+        end_time = start_time + Timedelta(days=1)
+        assert isinstance(end_time, pandas.Timestamp)
+
+        dimensions = [
+            {"Name": "hostname", "Value": "hostname1", "DimensionValueType": "VARCHAR"},
+            {"Name": "region", "Value": "us-west-2", "DimensionValueType": "VARCHAR"},
+        ]
+
+        record = {
+            "Dimensions": dimensions,
+            "MeasureName": "metrics",
+            "MeasureValueType": "MULTI",
+            "Time": str(start_time.value),
+            "TimeUnit": "NANOSECONDS",
+            "MeasureValues": [
+                {"Name": "value", "Value": "{\"dog_walk + run addition\": 0.1, \"dogsneakinteraction_smell\": 0.63}", "Type": "VARCHAR"},
+                {"Name": "memory_utilization", "Value": "33.8", "Type": "DOUBLE"},
+            ],
+        }
+
+        schema_tags = validator.get_quoted_tags(dimensions)
+
+        self.put_records([record])
+        unload.main(
+            [
+                "--database",
+                self.database_name,
+                "--table",
+                self.table_name,
+                "--s3-uri",
+                f"s3://{self.s3_bucket_name}",
+                "--start-time",
+                start_time.strftime(UNLOAD_TIMESTAMP_FORMAT),
+                "--end-time",
+                end_time.strftime(UNLOAD_TIMESTAMP_FORMAT),
+                "--export-table",
+            ]
+        )
+        transform.main(
+            [
+                "--database-name",
+                self.database_name,
+                "--tables",
+                self.table_name,
+                "--athena-database-name",
+                self.athena_database_name,
+                "--s3-bucket-path",
+                self.s3_bucket_name,
+                "--add-validation-field",
+                "true",
+            ]
+        )
+        self.s3_utility.sync_line_protocol_to_storage(
+            s3_bucket_path=self.s3_bucket_name,
+            directory=self.lp_directory,
+            timestream_database_name=self.database_name,
+            timestream_table_name=self.table_name,
+        )
+        influxdb_ingestion.main(
+            [
+                "-w",
+                "5",
+                "-l",
+                "5000",
+                "-m",
+                "5",
+                self.influxdb_bucket_name,
+                self.lp_directory,
+            ]
+        )
+        validator.main(
+            [
+                "--source-engine",
+                "athena",
+                "--athena-output",
+                "s3://" + self.s3_bucket_name,
+                "--athena-database-name",
+                self.athena_database_name,
+                "--athena-table-name",
+                self.athena_table_name,
+                "--influxdb-v2-url",
+                os.environ["INFLUXDB_V2_URL"],
+                "--influxdb-v2-token",
+                os.environ["INFLUXDB_V2_TOKEN"],
+                "--influxdb-v2-org",
+                os.environ["INFLUXDB_V2_ORG"],
+                "--influxdb-v2-bucket",
+                self.influxdb_bucket_name,
+                "--influxdb-v2-measurement",
+                self.table_name,
+                "--schema-tags",
+                schema_tags,
+                "--start-time",
+                start_time.strftime(ISO_8601_TIMESTAMP_FORMAT),
+                "--skip-wal-check",
+            ]
+        )
+
     def test_multi_measure_special_characters(self):
         """
         Tests the migration of data with special characters, characters

--- a/tools/python/liveanalytics_migration_scripts/tests/integration/test_influxdb_v2_target.py
+++ b/tools/python/liveanalytics_migration_scripts/tests/integration/test_influxdb_v2_target.py
@@ -759,7 +759,8 @@ class InfluxDbV2TargetTestCase(BaseIntegrationTestCase):
             "Time": str(start_time.value),
             "TimeUnit": "NANOSECONDS",
             "MeasureValues": [
-                {"Name": "value", "Value": "{\"dog_walk + run addition\": 0.1, \"dogsneakinteraction_smell\": 0.63}", "Type": "VARCHAR"},
+                {"Name": "value_uno", "Value": "{\"dog_walk_double + run addition\": 0.1, \"dogsneakinteraction_smell_double\": 0.63}", "Type": "VARCHAR"},
+                {"Name": "value_dos", "Value": "{'dog_walk_single + run addition': 0.1, 'dogsneakinteraction_smell_single': 0.63}", "Type": "VARCHAR"},
                 {"Name": "memory_utilization", "Value": "33.8", "Type": "DOUBLE"},
             ],
         }

--- a/tools/python/liveanalytics_migration_scripts/tests/integration/test_influxdb_v2_target.py
+++ b/tools/python/liveanalytics_migration_scripts/tests/integration/test_influxdb_v2_target.py
@@ -873,6 +873,11 @@ class InfluxDbV2TargetTestCase(BaseIntegrationTestCase):
                 "Value": "equals=in=dimension=value",
                 "DimensionValueType": "VARCHAR",
             },
+            {
+                "Name": "emojis🚀in🚀dimension🚀name",
+                "Value": "emojis🚀in🚀dimension🚀value",
+                "DimensionValueType": "VARCHAR",
+            },
         ]
 
         records = [
@@ -914,6 +919,20 @@ class InfluxDbV2TargetTestCase(BaseIntegrationTestCase):
                     {
                         "Name": "equals=in=measure=value=name",
                         "Value": "equals=in=measure=value",
+                        "Type": "VARCHAR",
+                    },
+                ],
+            },
+            {
+                "Dimensions": dimensions,
+                "MeasureName": "emojis🚀in🚀measure🚀name",
+                "MeasureValueType": "MULTI",
+                "Time": str(start_time.value),
+                "TimeUnit": "NANOSECONDS",
+                "MeasureValues": [
+                    {
+                        "Name": "emojies🚀in🚀measure🚀value🚀name",
+                        "Value": "emojis🚀in🚀measure🚀value",
                         "Type": "VARCHAR",
                     },
                 ],

--- a/tools/python/liveanalytics_migration_scripts/tests/test-requirements.txt
+++ b/tools/python/liveanalytics_migration_scripts/tests/test-requirements.txt
@@ -1,3 +1,3 @@
 -r ../requirements.txt
-pytest==7.4.0
-testcontainers==4.10.0
+pytest==8.4.2
+testcontainers==4.13.2


### PR DESCRIPTION
*Issue #, if available:*

N/A.

*Description of changes:*

Timestream for LiveAnalytics supports objects using the data type VARCHAR. These VARCHARs will include nested quotes. The Timestream for LiveAnalytics migration scripts have been updated to correctly escaped nested quotes, ensuring the resulting line protocol is valid.

An integration test has been added, confirming that nested quotes are properly escaped.

Additionally, the following dependencies have been updated to their latest versions:
- `psycopg2-binary`.
- `pyarrow`.
- `pytest`.
- `testcontainers`.

Tests:
- [X] `test_common.py`.
- [X] `test_influxdb_v2_target.py`.
- [X] `test_ingestion.py`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
