### PR TITLE
Fix import path for update logger in TfIDB ingestion script

### DIFF
--- a/tools/python/liveanalytics_migration_scripts/targets/timestream_for_influxdb/ingestion/influxdb_ingestion.py
+++ b/tools/python/liveanalytics_migration_scripts/targets/timestream_for_influxdb/ingestion/influxdb_ingestion.py
@@ -15,9 +15,12 @@ import multiprocessing
 from multiprocessing import Pool, current_process, Value
 from influxdb_client import InfluxDBClient
 from influxdb_client.client.write_api import SYNCHRONOUS
+from dotenv import load_dotenv
+
+sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../../")))
+
 from unload.utils.logger_utils import update_logger
 
-from dotenv import load_dotenv
 
 ingestion_logger = logging.getLogger("ingestion")
 


### PR DESCRIPTION
*Issue #, if available:*

N/A.

*Description of changes:*

Changes:
- Fix a broken import path for the update logger in the Timestream for InfluxDB ingestion script. The script now uses the same method of relative importing as all of the other scripts.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
