### PR TITLE
Fixing type bug for floats with the LiveAnalytics to InfluxDB 3 migration plugin

### DIFF
--- a/tools/python/liveanalytics_influxdb3_migration_plugin/liveanalytics_migration_client/liveanalytics_influxdb3_migration_client.py
+++ b/tools/python/liveanalytics_influxdb3_migration_plugin/liveanalytics_migration_client/liveanalytics_influxdb3_migration_client.py
@@ -32,7 +32,7 @@ class InfluxDBMigrationWrapper:
         db_name: str,
         s3_bucket_name: str,
         resume_migration: bool = False,
-        timeout_seconds: int = 120,
+        timeout_seconds: int = 1_200,
         region: str = "us-west-2",
     ) -> None:
         """
@@ -40,8 +40,10 @@ class InfluxDBMigrationWrapper:
 
         Args:
             db_name (str): Timestream for LiveAnalytics database name.
-            s3_bucket (str): S3 bucket name.
+            s3_bucket (str) S3 bucket name.
             resume_migration (bool): Whether to resume an existing migration, skipping unload operations.
+            timeout_seconds (int): The number of seconds to wait for each migration request.
+            region (str): The AWS Region to use.
 
         Returns:
             None
@@ -432,7 +434,7 @@ class InfluxDBMigrationWrapper:
                 )
                 trigger_invocation_response.raise_for_status()
                 response_body = trigger_invocation_response.json()
-                if response_body["status"] == "error":
+                if response_body["status"] != 200 and response_body["status"] != 202:
                     raise RuntimeError(
                         f"Migrating {s3_key} failed: {response_body['message']}"
                     )
@@ -455,8 +457,7 @@ class InfluxDBMigrationWrapper:
                     f"Final verification failed: {final_invocation_response.json()['message']}"
                 )
         except Exception as e:
-            self.error(f"HTTP invocation failed: {e}")
-            self.error("View processing engine logs for more information")
+            self.error(f"HTTP invocation failed: {e}. View processing engine logs for more information")
             sys.exit(1)
 
     def get_num_completed_and_total_parquet_files(self):

--- a/tools/python/liveanalytics_influxdb3_migration_plugin/liveanalytics_migration_client/liveanalytics_influxdb3_migration_client.py
+++ b/tools/python/liveanalytics_influxdb3_migration_plugin/liveanalytics_migration_client/liveanalytics_influxdb3_migration_client.py
@@ -32,7 +32,7 @@ class InfluxDBMigrationWrapper:
         db_name: str,
         s3_bucket_name: str,
         resume_migration: bool = False,
-        timeout_seconds: int = 1_200,
+        timeout_seconds: int = 120,
         region: str = "us-west-2",
     ) -> None:
         """
@@ -40,7 +40,7 @@ class InfluxDBMigrationWrapper:
 
         Args:
             db_name (str): Timestream for LiveAnalytics database name.
-            s3_bucket (str) S3 bucket name.
+            s3_bucket (str): S3 bucket name.
             resume_migration (bool): Whether to resume an existing migration, skipping unload operations.
             timeout_seconds (int): The number of seconds to wait for each migration request.
             region (str): The AWS Region to use.

--- a/tools/python/liveanalytics_influxdb3_migration_plugin/liveanalytics_migration_plugin/liveanalytics_migration_plugin.py
+++ b/tools/python/liveanalytics_influxdb3_migration_plugin/liveanalytics_migration_plugin/liveanalytics_migration_plugin.py
@@ -462,14 +462,15 @@ def ingest_parquet_file_in_chunks(
     for batch in read_parquet_in_batches(influxdb3_local, presigned_get_url, s3_key):
         chunk_number += 1
         batch_schema = batch.schema
-        field_types = []
+        column_types = []
         for field in batch_schema:
+            # We only care about double and int64 as other panda data types can be inferred during line protocol generation
             if pa.types.is_floating(field.type):
-                field_types.append(("double", field.name))
+                column_types.append(("double", field.name))
             elif pa.types.is_integer(field.type):
-                field_types.append(("int64", field.name))
+                column_types.append(("int64", field.name))
             else:
-                field_types.append(("skip", field.name))
+                column_types.append(("skip", field.name))
         df_chunk = batch.to_pandas()
 
         influxdb3_local.info(
@@ -478,7 +479,7 @@ def ingest_parquet_file_in_chunks(
 
         # Process each record in the chunk.
         for row in df_chunk.itertuples(index=False, name=None):
-            line_protocol = transform_row_to_lp(influxdb3_local, row, table_name, field_types)
+            line_protocol = transform_row_to_lp(influxdb3_local, row, table_name, column_types)
             if len(line_protocol.fields.items()) == 0:
                 influxdb3_local.info(
                     f"Line protocol was ignored as no fields were set: {line_protocol}"
@@ -507,7 +508,7 @@ def ingest_parquet_file_in_chunks(
     )
 
 
-def transform_row_to_lp(influxdb3_local, row, table_name, field_types):
+def transform_row_to_lp(influxdb3_local, row, table_name, column_types):
     """
     Transforms data into LineBuilder objects for writing to InfluxDB.
 
@@ -515,7 +516,7 @@ def transform_row_to_lp(influxdb3_local, row, table_name, field_types):
         influxdb3_local (InfluxDB client): Logging and ingestion client
         row (string): Row in parquet file
         table_name (string): Table name
-        field_types(array): Array of field types (only includes double and int64)
+        column_types(dict): Column types and names (only includes types double and int64)
 
     Returns:
         LineBuilder: LineBuilder object ready for writing to InfluxDB.
@@ -524,12 +525,12 @@ def transform_row_to_lp(influxdb3_local, row, table_name, field_types):
     builder = LineBuilder(table_name)
     parse_dimensions = True
 
-    for (field_type, col), val in zip(field_types, row):
-        col_lower = col.lower()
+    for (column_type, column_name), val in zip(column_types, row):
+        col_lower = column_name.lower()
         if pandas.isna(val):
             continue
         elif col_lower in ["measure_name"]:
-            builder.tag(col, val)
+            builder.tag(column_name, val)
         elif col_lower in ["time"]:
             try:
                 ts = pandas.to_datetime(val)
@@ -545,23 +546,23 @@ def transform_row_to_lp(influxdb3_local, row, table_name, field_types):
         elif parse_dimensions and isinstance(
             val, (str, numpy.bool_, pandas.StringDtype().type)
         ):
-            builder.tag(col, val)
+            builder.tag(column_name, val)
         elif not parse_dimensions and (pandas.isna(val) or val is None):
             influxdb3_local.info(
-                f"Skipping field value with nulled or missing value for column {col}"
+                f"Skipping field value with nulled or missing value for column {column_name}"
             )
         elif isinstance(val, pandas.Timestamp):
-            builder.string_field(col, str(val))
-        elif field_type == "double" and isinstance(val, (float, numpy.floating)):
-            builder.float64_field(col, float(val))
-        elif field_type == "int64" and isinstance(val, (int, numpy.integer)):
-            builder.int64_field(col, int(val))
+            builder.string_field(column_name, str(val))
+        elif column_type == "double":
+            builder.float64_field(column_name, float(val))
+        elif column_type == "int64":
+            builder.int64_field(column_name, numpy.int64(val))
         elif isinstance(val, str):
-            builder.string_field(col, val)
+            builder.string_field(column_name, val)
         elif isinstance(val, (bool, numpy.bool_, pandas.BooleanDtype().type)):
-            builder.bool_field(col, bool(val))
+            builder.bool_field(column_name, bool(val))
         else:
-            influxdb3_local.error(f"Failed to parse type: {type(val)} row {row}")
+            influxdb3_local.error(f"Failed to parse column name: {column_name} value: {val} type: {column_type}")
 
     return builder
 

--- a/tools/python/liveanalytics_influxdb3_migration_plugin/liveanalytics_migration_plugin/liveanalytics_migration_plugin.py
+++ b/tools/python/liveanalytics_influxdb3_migration_plugin/liveanalytics_migration_plugin/liveanalytics_migration_plugin.py
@@ -471,7 +471,7 @@ def ingest_parquet_file_in_chunks(
                 column_types.append(("int64", field.name))
             else:
                 column_types.append(("skip", field.name))
-        df_chunk = batch.to_pandas()
+        df_chunk = batch.to_pandas(types_mapper={pa.int64(): pandas.Int64Dtype()}.get)
 
         influxdb3_local.info(
             f"Processing Chunk {chunk_number} ({len(df_chunk):,} records)"

--- a/tools/python/liveanalytics_influxdb3_migration_plugin/liveanalytics_migration_plugin/liveanalytics_migration_plugin.py
+++ b/tools/python/liveanalytics_influxdb3_migration_plugin/liveanalytics_migration_plugin/liveanalytics_migration_plugin.py
@@ -515,7 +515,7 @@ def transform_row_to_lp(influxdb3_local, row, table_name, field_types):
         influxdb3_local (InfluxDB client): Logging and ingestion client
         row (string): Row in parquet file
         table_name (string): Table name
-        field_types(array): Array of field types (only includes double and int64)
+        field_types (list[tuple[str, Any]]): Array of field types, which only includes double, float, and int64.
 
     Returns:
         LineBuilder: LineBuilder object ready for writing to InfluxDB.
@@ -545,7 +545,7 @@ def transform_row_to_lp(influxdb3_local, row, table_name, field_types):
         elif parse_dimensions and isinstance(
             val, (str, numpy.bool_, pandas.StringDtype().type)
         ):
-            builder.tag(col, val)
+            builder.tag(col_name, val)
         elif not parse_dimensions and (pandas.isna(val) or val is None):
             influxdb3_local.info(
                 f"Skipping field value with nulled or missing value for column {col}"

--- a/tools/python/liveanalytics_influxdb3_migration_plugin/liveanalytics_migration_plugin/liveanalytics_migration_plugin.py
+++ b/tools/python/liveanalytics_influxdb3_migration_plugin/liveanalytics_migration_plugin/liveanalytics_migration_plugin.py
@@ -468,7 +468,7 @@ def ingest_parquet_file_in_chunks(
 
         # Process each record in the chunk.
         for row in df_chunk.itertuples(index=False):
-            line_protocol = transform_row_to_lp(influxdb3_local, row, table_name)
+            line_protocol = transform_row_to_lp(influxdb3_local, row, table_name, batch.schema)
             if len(line_protocol.fields.items()) == 0:
                 influxdb3_local.info(
                     f"Line protocol was ignored as no fields were set: {line_protocol}"
@@ -497,7 +497,7 @@ def ingest_parquet_file_in_chunks(
     )
 
 
-def transform_row_to_lp(influxdb3_local, row, table_name):
+def transform_row_to_lp(influxdb3_local, row, table_name, schema):
     """
     Transforms data into LineBuilder objects for writing to InfluxDB.
 
@@ -505,6 +505,7 @@ def transform_row_to_lp(influxdb3_local, row, table_name):
         influxdb3_local (InfluxDB client): Logging and ingestion client
         row (string): Row in parquet file
         table_name (string): Table name
+        schema(pyarrow.Schema): Schema for table
 
     Returns:
         LineBuilder: LineBuilder object ready for writing to InfluxDB.
@@ -539,18 +540,18 @@ def transform_row_to_lp(influxdb3_local, row, table_name):
             influxdb3_local.info(
                 f"Skipping field value with nulled or missing value for column {col}"
             )
-        elif isinstance(val, pandas.Timestamp):
+        elif schema.field(col).type == "timestamp[ns]" and isinstance(val, pandas.Timestamp):
             builder.string_field(col, str(val))
-        elif isinstance(val, (float, numpy.floating)):
+        elif schema.field(col).type == "double":
             builder.float64_field(col, float(val))
-        elif isinstance(val, (int, numpy.integer)):
+        elif schema.field(col).type == "int64":
             builder.int64_field(col, int(val))
-        elif isinstance(val, str):
+        elif schema.field(col).type == "string" and isinstance(val, str):
             builder.string_field(col, val)
-        elif isinstance(val, (bool, numpy.bool_, pandas.BooleanDtype().type)):
+        elif schema.field(col).type == "bool" and isinstance(val, (bool, numpy.bool_, pandas.BooleanDtype().type)):
             builder.bool_field(col, bool(val))
         else:
-            influxdb3_local.error(f"Failed to parse type: {type(val)} row {row}")
+            influxdb3_local.error(f"Failed to parse data type: {type(val)} row: {row} column type: {schema.field(col).type}")
 
     return builder
 

--- a/tools/python/liveanalytics_influxdb3_migration_plugin/liveanalytics_migration_plugin/liveanalytics_migration_plugin.py
+++ b/tools/python/liveanalytics_influxdb3_migration_plugin/liveanalytics_migration_plugin/liveanalytics_migration_plugin.py
@@ -7,6 +7,7 @@ import time
 import numpy
 import pandas
 import pyarrow.parquet as pq
+import pyarrow as pa
 import requests
 
 
@@ -460,6 +461,15 @@ def ingest_parquet_file_in_chunks(
     # Read the file in batches.
     for batch in read_parquet_in_batches(influxdb3_local, presigned_get_url, s3_key):
         chunk_number += 1
+        batch_schema = batch.schema
+        field_types = []
+        for field in batch_schema:
+            if pa.types.is_floating(field.type):
+                field_types.append(("double", field.name))
+            elif pa.types.is_integer(field.type):
+                field_types.append(("int64", field.name))
+            else:
+                field_types.append(("skip", field.name))
         df_chunk = batch.to_pandas()
 
         influxdb3_local.info(
@@ -467,8 +477,8 @@ def ingest_parquet_file_in_chunks(
         )
 
         # Process each record in the chunk.
-        for row in df_chunk.itertuples(index=False):
-            line_protocol = transform_row_to_lp(influxdb3_local, row, table_name, batch.schema)
+        for row in df_chunk.itertuples(index=False, name=None):
+            line_protocol = transform_row_to_lp(influxdb3_local, row, table_name, field_types)
             if len(line_protocol.fields.items()) == 0:
                 influxdb3_local.info(
                     f"Line protocol was ignored as no fields were set: {line_protocol}"
@@ -497,7 +507,7 @@ def ingest_parquet_file_in_chunks(
     )
 
 
-def transform_row_to_lp(influxdb3_local, row, table_name, schema):
+def transform_row_to_lp(influxdb3_local, row, table_name, field_types):
     """
     Transforms data into LineBuilder objects for writing to InfluxDB.
 
@@ -505,7 +515,7 @@ def transform_row_to_lp(influxdb3_local, row, table_name, schema):
         influxdb3_local (InfluxDB client): Logging and ingestion client
         row (string): Row in parquet file
         table_name (string): Table name
-        schema(pyarrow.Schema): Schema for table
+        field_types(array): Array of field types (only includes double and int64)
 
     Returns:
         LineBuilder: LineBuilder object ready for writing to InfluxDB.
@@ -514,7 +524,7 @@ def transform_row_to_lp(influxdb3_local, row, table_name, schema):
     builder = LineBuilder(table_name)
     parse_dimensions = True
 
-    for col, val in zip(row._fields, row):
+    for (field_type, col), val in zip(field_types, row):
         col_lower = col.lower()
         if pandas.isna(val):
             continue
@@ -540,18 +550,18 @@ def transform_row_to_lp(influxdb3_local, row, table_name, schema):
             influxdb3_local.info(
                 f"Skipping field value with nulled or missing value for column {col}"
             )
-        elif schema.field(col).type == "timestamp[ns]" and isinstance(val, pandas.Timestamp):
+        elif isinstance(val, pandas.Timestamp):
             builder.string_field(col, str(val))
-        elif schema.field(col).type == "double":
+        elif field_type == "double" and isinstance(val, (float, numpy.floating)):
             builder.float64_field(col, float(val))
-        elif schema.field(col).type == "int64":
+        elif field_type == "int64" and isinstance(val, (int, numpy.integer)):
             builder.int64_field(col, int(val))
-        elif schema.field(col).type == "string" and isinstance(val, str):
+        elif isinstance(val, str):
             builder.string_field(col, val)
-        elif schema.field(col).type == "bool" and isinstance(val, (bool, numpy.bool_, pandas.BooleanDtype().type)):
+        elif isinstance(val, (bool, numpy.bool_, pandas.BooleanDtype().type)):
             builder.bool_field(col, bool(val))
         else:
-            influxdb3_local.error(f"Failed to parse data type: {type(val)} row: {row} column type: {schema.field(col).type}")
+            influxdb3_local.error(f"Failed to parse type: {type(val)} row {row}")
 
     return builder
 

--- a/tools/python/liveanalytics_influxdb3_migration_plugin/liveanalytics_migration_plugin/liveanalytics_migration_plugin.py
+++ b/tools/python/liveanalytics_influxdb3_migration_plugin/liveanalytics_migration_plugin/liveanalytics_migration_plugin.py
@@ -512,10 +512,10 @@ def transform_row_to_lp(influxdb3_local, row, table_name, field_types):
     Transforms data into LineBuilder objects for writing to InfluxDB.
 
     Args:
-        influxdb3_local (InfluxDB client): Logging and ingestion client
-        row (string): Row in parquet file
-        table_name (string): Table name
-        field_types (list[tuple[str, Any]]): Array of field types, which only includes double, float, and int64.
+        influxdb3_local (InfluxDB client): Logging and ingestion client.
+        row (str): Row in parquet file.
+        table_name (str): Table name.
+        field_types (list[tuple[str, Any]]): List of field types (only includes double and int64).
 
     Returns:
         LineBuilder: LineBuilder object ready for writing to InfluxDB.
@@ -545,7 +545,7 @@ def transform_row_to_lp(influxdb3_local, row, table_name, field_types):
         elif parse_dimensions and isinstance(
             val, (str, numpy.bool_, pandas.StringDtype().type)
         ):
-            builder.tag(col_name, val)
+            builder.tag(col, val)
         elif not parse_dimensions and (pandas.isna(val) or val is None):
             influxdb3_local.info(
                 f"Skipping field value with nulled or missing value for column {col}"


### PR DESCRIPTION
*Description of changes:*

Fixing a bug where `int` is treated as a `float`. Pyarrow type cannot be inferred without the schema as `int` can be represented as `float` by arrow to pandas conversion.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
