### PR TITLE
Support migrations to InfluxDB v2

### DIFF
--- a/tools/python/influxdb_v2_to_v3_migration/README.md
+++ b/tools/python/influxdb_v2_to_v3_migration/README.md
@@ -84,7 +84,7 @@ rm -rf ~/engine
 
 ## Migrating to InfluxDB v2
 
-`influxdb_v2_to_v3_migration.py` can be used to migrate data from an InfluxDB v2 instance to InfluxDB v2. This can be useful, if, for example, you have a source InfluxDB v2 instance and want to migrate all of your data to an InfluxDB cluster. InfluxDB cluster's don't support the `backup` or `restore` InfluxDB v2 CLI commands, so using `influxdb_v2_to_v3_migration.py`, which ingests using write APIs, is an alternative migration path.
+`influxdb_v2_to_v3_migration.py` can be used to migrate data from an InfluxDB v2 instance to InfluxDB v2. This can be useful, if, for example, you have a source InfluxDB v2 instance and want to migrate all of your data to an InfluxDB cluster. InfluxDB clusters don't support the `backup` or `restore` InfluxDB v2 CLI commands, so using `influxdb_v2_to_v3_migration.py`, which ingests using write APIs, is an alternate migration path.
 
 To migrate to InfluxDB v2, follow the same steps as above, but provide the argument `--destination-org` to `influxdb_v2_to_v3_migration.py` or `influxdb_v3_ingestion.py` with the name of an existing organization in your destination.
 

--- a/tools/python/influxdb_v2_to_v3_migration/README.md
+++ b/tools/python/influxdb_v2_to_v3_migration/README.md
@@ -2,7 +2,7 @@
 
 ## Overview
 
-The [Amazon Timestream for InfluxDB](https://docs.aws.amazon.com/timestream/latest/developerguide/timestream-for-influxdb.html) [v2](https://docs.influxdata.com/influxdb/v2/) to [v3](https://docs.influxdata.com/influxdb3/enterprise/) migration script allows you to migrate your data from managed InfluxDB v2 to v3.
+The [Amazon Timestream for InfluxDB](https://docs.aws.amazon.com/timestream/latest/developerguide/timestream-for-influxdb.html) [v2](https://docs.influxdata.com/influxdb/v2/) to [v3](https://docs.influxdata.com/influxdb3/enterprise/) migration script allows you to migrate your data from managed InfluxDB v2 to v2 or v3.
 
 The script is available standalone or as part of an automated solution that deploys an EC2 instance with the script and all prerequisites installed. To use the automated solution, see the [`README` in the `automated_deployment/` directory](./automated_deployment/README.md).
 
@@ -64,14 +64,14 @@ In this diagram, data is being migrated from Timestream for InfluxDB v2 to Times
     - Your InfluxDB v2 URL.
     - Your InfluxDB v3 URL.
     - Either:
-      - The InfluxDB v2 buckets that you want to migrate and their organizations, with `--influxdb-v2-buckets-and-orgs`.
-      - Or, the names of the organizations to migrate all buckets from, with `--influxdb-v2-orgs`.
+      - The InfluxDB v2 buckets that you want to migrate and their organizations, with `--source-buckets-and-orgs`.
+      - Or, the names of the organizations to migrate all buckets from, with `--source-orgs`.
     - The name of the secret you created in AWS Secrets Manager that contains your InfluxDB v2 and v3 tokens.
     ```shell
     python3.13 influxdb_v2_to_v3_migration.py \
-        --influxdb-v2-url "https://example.com:8086" \
-        --influxdb-v3-url "https://example.com:8181" \
-        --influxdb-v2-buckets-and-orgs "bucket-one:organization-one,bucket-two:organization-two" \
+        --source-url "https://example.com:8086" \
+        --destination-url "https://example.com:8181" \
+        --source-buckets-and-orgs "bucket-one:organization-one,bucket-two:organization-two" \
         --tokens-secret-name "influxdb_v2_to_v3_migration"
     ```
 
@@ -81,6 +81,14 @@ Remove the backed-up data. By default, data is placed in `~/engine`:
 ```
 rm -rf ~/engine
 ```
+
+## Migrating to InfluxDB v2
+
+`influxdb_v2_to_v3_migration.py` can be used to migrate data from an InfluxDB v2 instance to InfluxDB v2. This can be useful, if, for example, you have a source InfluxDB v2 instance and want to migrate all of your data to an InfluxDB cluster. InfluxDB cluster's don't support the `backup` or `restore` InfluxDB v2 CLI commands, so using `influxdb_v2_to_v3_migration.py`, which ingests using write APIs, is an alternative migration path.
+
+To migrate to InfluxDB v2, follow the same steps as above, but provide the argument `--destination-org` to `influxdb_v2_to_v3_migration.py` or `influxdb_v3_ingestion.py` with the name of an existing organization in your destination.
+
+**All** data will be migrated to the organization you specify.
 
 ## Manual Verification
 
@@ -116,7 +124,7 @@ To compare the total number of records in an InfluxDB v3 database to the known n
 
 ## InfluxDB v3 Ingestion
 
-A script, `./app/influxdb_v3_ingestion.py`, is provided that ingests data to Timestream for InfluxDB v3. This script is useful if you have already backed up your InfluxDB v2 data. The ingestion script is tailored to be used by the end-to-end migration script, and expects data to be organized in a specific way. To organize data the way that the ingestion script expects, you can backup, extract InfluxDB v2 data, and convert InfluxDB v2 data to line protocol using the following commands:
+A script, `./app/influxdb_v3_ingestion.py`, is provided that ingests data to Timestream for InfluxDB v2 or v3. This script is useful if you have already backed up your InfluxDB v2 data. The ingestion script is tailored to be used by the end-to-end migration script, and expects data to be organized in a specific way. To organize data the way that the ingestion script expects, you can backup, extract InfluxDB v2 data, and convert InfluxDB v2 data to line protocol using the following commands:
 ```shell
 # Required input values.
 INFLUXDB_V2_HOST=<InfluxDB v2 host>
@@ -155,7 +163,7 @@ for bucket_id in $(ls -1d ~/engine/data/*/ | xargs -n 1 basename); do
 done
 ```
 
-Once your data is available in a `engine/data/` directory, `influxdb_v3_ingestion.py` can be used to ingest your data to InfluxDB v3:
+Once your data is available in a `engine/data/` directory, `influxdb_v3_ingestion.py` can be used to ingest your data to InfluxDB v2 or v3:
 ```shell
 # The AWS Secrets Manager secret holding InfluxDB v2 and v3 tokens.
 TOKENS_SECRET_NAME=<tokens secret name>
@@ -173,8 +181,8 @@ BUCKET_NAMES_AND_IDS="${BUCKET_NAMES_AND_IDS%?}"
 
 # Ingest data.
 python3 influxdb_v3_ingestion.py \
-    --influxdb-v3-url $INFLUXDB_V3_HOST \
-    --influxdb-v2-bucket-names-and-ids $BUCKET_NAMES_AND_IDS \
+    --url $INFLUXDB_V3_HOST \
+    --source-buckets-and-ids $BUCKET_NAMES_AND_IDS \
     --tokens-secret-name $TOKENS_SECRET_NAME \
     --backup-path ~/engine/data
 ```
@@ -200,6 +208,10 @@ python3 influxdb_v3_ingestion.py --help
    These tests will create a secret in AWS Secrets Manager, create Docker containers for InfluxDB v2 OSS and v3 Core, create a temporary directory for migrations, and perform a number of migrations. Tests should clean up all resources after they have finished. Errors during teardown, if any occur, may leave residual resources.
 
 ## FAQ
+
+### Can you migrate to InfluxDB v2?
+
+Yes, simply supply the name of an existing org with `--destination-org` as an argument to `influxdb_v2_to_v3_migration.py` or `influxdb_v3_ingestion.py`. All data will be migrated to this organization. See the above [Migrating to InfluxDB v2](#migrating-to-influxdb-v2) section.
 
 ### What is the cutoff time for migrated points?
 All points before the migration begins will be migrated. Points ingested after or during the migration will not. This is due to the behaviour of the InfluxDB v2 CLI.

--- a/tools/python/influxdb_v2_to_v3_migration/automated_deployment/README.md
+++ b/tools/python/influxdb_v2_to_v3_migration/automated_deployment/README.md
@@ -212,14 +212,14 @@ To use the migration script and deploy all resources, you must have the followin
     - Your InfluxDB v2 URL.
     - Your InfluxDB v3 URL.
     - Either:
-      - The InfluxDB v2 buckets that you want to migrate and their organizations, with `--influxdb-v2-buckets-and-orgs`.
-      - Or, the names of the organizations to migrate all buckets from, with `--influxdb-v2-orgs`.
+      - The InfluxDB v2 buckets that you want to migrate and their organizations, with `--source-buckets-and-orgs`.
+      - Or, the names of the organizations to migrate all buckets from, with `--source-orgs`.
     - The name of the secret you created in AWS Secrets Manager that contains your InfluxDB v2 and v3 tokens.
     ```shell
     python influxdb_v2_to_v3_migration.py \
-        --influxdb-v2-url "https://example.com:8086" \
-        --influxdb-v3-url "https://example.com:8181" \
-        --influxdb-v2-buckets-and-orgs "bucket-one:organization-one,bucket-two:organization-two" \
+        --source-url "https://example.com:8086" \
+        --destination-url "https://example.com:8181" \
+        --source-buckets-and-orgs "bucket-one:organization-one,bucket-two:organization-two" \
         --tokens-secret-name "influxdb_v2_to_v3_migration"
     ```
     - **Note**: Packer installs Python 3.13 in the AMI simply as `python`.

--- a/tools/python/influxdb_v2_to_v3_migration/automated_deployment/variables.tf
+++ b/tools/python/influxdb_v2_to_v3_migration/automated_deployment/variables.tf
@@ -20,8 +20,8 @@ variable "tokens" {
   sensitive = true
   type      = map(string)
   default = {
-    INFLUXDB_V2_TOKEN = "replace me"
-    INFLUXDB_V3_TOKEN = "replace me"
+    SOURCE_TOKEN = "replace me"
+    DESTINATION_TOKEN = "replace me"
   }
 }
 

--- a/tools/python/influxdb_v2_to_v3_migration/influxdb_v2_to_v3_migration.py
+++ b/tools/python/influxdb_v2_to_v3_migration/influxdb_v2_to_v3_migration.py
@@ -439,17 +439,17 @@ def get_buckets_from_orgs(
 def main(input_args: list[str]) -> int:
     parser: argparse.ArgumentParser = argparse.ArgumentParser(
         prog="influxdb_v2_to_v3_migration",
-        description="A script that migrates data from InfluxDB v2 to InfluxDB v3",
+        description="A script that migrates data from InfluxDB v2 to InfluxDB v2 or v3",
     )
     _ = parser.add_argument(
-        "--influxdb-v2-url",
+        "--source-url",
         required=True,
         help="The InfluxDB v2 URL to migrate from. Example: https://example.com:8086",
     )
     _ = parser.add_argument(
-        "--influxdb-v3-url",
+        "--destination-url",
         required=True,
-        help="The InfluxDB v3 URL to migrate to. Example: https://example.com:8181",
+        help="The destination InfluxDB v2 or v3 URL to migrate to. Example: https://example.com:8181",
     )
     _ = parser.add_argument(
         "--backup-path-root",
@@ -518,10 +518,10 @@ def main(input_args: list[str]) -> int:
         ),
     )
     _ = parser.add_argument(
-        "--influxdb-v3-database-retention-period",
+        "--destination-retention-period",
         required=False,
         help=(
-            "The retention period to use for all new InfluxDB v3 databases. Retention periods can be updated later. "
+            "The retention period to use for all new InfluxDB v2 buckets or v3 databases. Retention periods can be updated later. "
             "For example, '1d', '30m'. By default, this is infinity."
         ),
     )
@@ -531,9 +531,15 @@ def main(input_args: list[str]) -> int:
         required=False,
         help="The AWS region to use for AWS Secrets Manager.",
     )
+    _ = parser.add_argument(
+        "--destination-org",
+        default="organization",
+        required=False,
+        help="The destination InfluxDB v2 organization to use.",
+    )
     mutually_exclusive_group = parser.add_mutually_exclusive_group(required=True)
     _ = mutually_exclusive_group.add_argument(
-        "--influxdb-v2-buckets-and-orgs",
+        "--source-buckets-and-orgs",
         help=(
             "A list of bucket names paired with the organization each bucket resides in. "
             "Example: 'bucket-one:org-one,bucket-two:org-two'. The separators used in this "
@@ -541,7 +547,7 @@ def main(input_args: list[str]) -> int:
         ),
     )
     _ = mutually_exclusive_group.add_argument(
-        "--influxdb-v2-orgs",
+        "--source-orgs",
         help=(
             "A list of organization names from which to migrate all buckets. "
             "Example: org-one,org-two,org-three"
@@ -551,8 +557,8 @@ def main(input_args: list[str]) -> int:
     args = parser.parse_args(input_args)
 
     tokens_secret_name: str = args.tokens_secret_name
-    influxdb_v2_url: str = args.influxdb_v2_url
-    influxdb_v3_url: str = args.influxdb_v3_url
+    source_url: str = args.source_url
+    destination_url: str = args.destination_url
     start_time: str | None = args.start_time
     end_time: str | None = args.end_time
     num_backup_workers: int = args.num_backup_workers
@@ -574,10 +580,10 @@ def main(input_args: list[str]) -> int:
         tokens: dict[str, str] = utils.get_secret(
             secret_name=tokens_secret_name, region_name=region_name
         )
-        influxdb_v2_token: str | None = tokens.get("INFLUXDB_V2_TOKEN")
-        influxdb_v3_token: str | None = tokens.get("INFLUXDB_V3_TOKEN")
-        assert influxdb_v2_token is not None
-        assert influxdb_v3_token is not None
+        source_token: str | None = tokens.get("SOURCE_TOKEN")
+        destination_token: str | None = tokens.get("DESTINATION_TOKEN")
+        assert source_token is not None
+        assert destination_token is not None
 
         logger.info(
             f"Successfully retrieved tokens from Secrets Manager: {tokens_secret_name}"
@@ -586,43 +592,42 @@ def main(input_args: list[str]) -> int:
         logger.error(f"Failed to retrieve tokens from Secrets Manager: {str(e)}")
         return 1
 
-    logger.info(f"Using InfluxDB v2 URL: {influxdb_v2_url}")
-    logger.info(f"Using InfluxDB v3 URL: {influxdb_v3_url}")
+    logger.info(f"Using source URL: {source_url}")
+    logger.info(f"Using destination URL: {destination_url}")
 
-    if not health_check(influxdb_v2_url, influxdb_v2_token):
-        logger.error("Unable to reach InfluxDB v2 instance")
+    if not health_check(source_url, source_token):
+        logger.error(f"Unable to reach source instance {source_url}")
         return 1
     else:
-        logger.info("InfluxDB v2 instance is reachable")
+        logger.info("Source instance is reachable")
 
-    if not health_check(influxdb_v3_url, influxdb_v3_token):
-        logger.error("Unable to reach InfluxDB v3 instance")
+    if not health_check(destination_url, destination_token):
+        logger.error(f"Unable to reach destination instance {destination_url}")
         return 1
     else:
-        logger.info("InfluxDB v3 instance is reachable")
+        logger.info("Destination instance is reachable")
 
-    if args.influxdb_v2_orgs is not None:
-        bucket_org_pairs: list[tuple[str, str]] = get_buckets_from_orgs(
-            influxdb_v2_url,
-            influxdb_v2_token,
-            args.influxdb_v2_orgs,
+    bucket_org_pairs: list[tuple[str, str]] = []
+    if args.source_orgs is not None:
+        bucket_org_pairs = get_buckets_from_orgs(
+            source_url,
+            source_token,
+            args.source_orgs,
             args.org_separator,
         )
 
-    if args.influxdb_v2_buckets_and_orgs is not None:
-        bucket_org_pairs: list[tuple[str, str]] = [
+    if args.source_buckets_and_orgs is not None:
+        bucket_org_pairs = [
             (bucket_name, org_name)
             for bucket_name, org_name in (
                 pair.split(args.bucket_org_separator, 1)
-                for pair in args.influxdb_v2_buckets_and_orgs.split(
-                    args.bucket_separator
-                )
+                for pair in args.source_buckets_and_orgs.split(args.bucket_separator)
             )
         ]
 
     backup_result: bool = backup_influxdb_v2_buckets(
-        influxdb_v2_url,
-        influxdb_v2_token,
+        source_url,
+        source_token,
         bucket_org_pairs,
         backup_path,
         num_backup_workers,
@@ -638,8 +643,8 @@ def main(input_args: list[str]) -> int:
 
     export_lp_result: tuple[bool, list[tuple[str, str]]] = (
         export_influxdb_v2_buckets_to_lp(
-            influxdb_v2_url,
-            influxdb_v2_token,
+            source_url,
+            source_token,
             bucket_org_pairs,
             backup_path,
             start_time,
@@ -662,12 +667,13 @@ def main(input_args: list[str]) -> int:
             )
 
     ingestion_result: bool = influxdb_v3_ingestion.ingest_line_protocol_files(
-        influxdb_v3_url=args.influxdb_v3_url,
-        influxdb_v3_token=influxdb_v3_token,
+        url=args.destination_url,
+        token=destination_token,
+        org=args.destination_org,
         backup_path=backup_path,
         bucket_id_pairs=export_lp_result[1],
         num_workers=args.num_ingestion_workers,
-        retention_period=args.influxdb_v3_database_retention_period,
+        retention_period=args.destination_retention_period,
     )
 
     if ingestion_result:

--- a/tools/python/influxdb_v2_to_v3_migration/influxdb_v3_ingestion.py
+++ b/tools/python/influxdb_v2_to_v3_migration/influxdb_v3_ingestion.py
@@ -16,7 +16,6 @@ from pathlib import Path
 from influxdb_client_3 import (
     InfluxDBClient3,
 )
-from requests.models import HTTPError
 
 import utils
 
@@ -194,8 +193,9 @@ def read_outer_chunks(
 
 
 def ingest_line_protocol_files(
-    influxdb_v3_url: str,
-    influxdb_v3_token: str,
+    url: str,
+    token: str,
+    org: str | None,
     backup_path: Path,
     bucket_id_pairs: list[tuple[str, str]],
     lines_per_batch: int = 10_000,
@@ -208,8 +208,9 @@ def ingest_line_protocol_files(
     Ingests line protocol files from a local directory to InfluxDB v3.
 
     Args:
-        influxdb_v3_url (str): The InfluxDB v3 URL, including scheme and port.
-        influxdb_v3_token (str): The InfluxDB v3 token.
+        url (str): The InfluxDB v2 or v3 URL, including scheme and port.
+        token (str): The InfluxDB v2 or v3 token.
+        org (str | None): The name of the InfluxDB v2 organization to use.
         backup_path (Path): The path containing the line protocol files.
         bucket_id_pairs (list[tuple[str, str]]): A list of bucket names and bucket ID pairs.
             Bucket names will be used to create new InfluxDB v3 databases and bucket IDs will be
@@ -234,8 +235,9 @@ def ingest_line_protocol_files(
         futures = {
             executor.submit(
                 ingest_line_protocol_file,
-                influxdb_v3_url,
-                influxdb_v3_token,
+                url,
+                token,
+                org,
                 backup_path,
                 bucket_id_pair,
                 lines_per_batch,
@@ -267,8 +269,9 @@ def ingest_line_protocol_files(
 
 
 def ingest_line_protocol_file(
-    influxdb_v3_url: str,
-    influxdb_v3_token: str,
+    url: str,
+    token: str,
+    org: str | None,
     backup_path: Path,
     bucket_name_id_pair: tuple[str, str],
     lines_per_batch: int = 10_000,
@@ -280,8 +283,9 @@ def ingest_line_protocol_file(
     Ingest a line protocol file into InfluxDB v3.
 
     Args:
-        influxdb_v3_url (str): The InfluxDB v3 URL, including scheme and port.
-        influxdb_v3_token (str): The InfluxDB v3 token.
+        url (str): The InfluxDB v2 or v3 URL, including scheme and port.
+        token (str): The InfluxDB v2 or v3 token.
+        org (str | None): The name of the InfluxDB v2 organization to use.
         backup_path (Path): The path where line protocol files reside.
         bucket_name_id_pair (tuple[str, str]): A tuple containing a bucket's name and ID.
         lines_per_batch (int): Number of lines to ingest in each batch.
@@ -299,51 +303,56 @@ def ingest_line_protocol_file(
 
     # Databases in InfluxDB v3 cannot contain underscores (_), must start
     # and begin with an alphanumeric character, and are allowed to use hyphens.
-    database_name: str = bucket_name.replace("_", "-")
+    database_or_bucket_name: str = bucket_name.replace("_", "-")
 
     lp_file_path: Path = backup_path / Path(bucket_id) / Path(f"{bucket_name}.lp")
-
-    response: requests.Response = requests.get(
-        f"{influxdb_v3_url}/api/v3/configure/database?format=json",
-        headers={"Authorization": f"Bearer {influxdb_v3_token}"},
-    )
-    try:
-        response.raise_for_status()
-    except HTTPError as e:
-        error_message = f"Failed to list existing InfluxDB v3 databases: {e}"
-        logger.error(error_message)
-        raise RuntimeError(error_message)
-
-    list_databases_response = response.json()
-
-    if any(database_name in database.values() for database in list_databases_response):
-        logger.info(f"Database {database_name} exists")
-    else:
-        logger.info(f"Creating database {database_name}")
-
-        database_creation_body = {"db": database_name}
-        if retention_period is not None:
-            database_creation_body["retention_period"] = retention_period
-
-        response = requests.post(
-            f"{influxdb_v3_url}/api/v3/configure/database",
-            headers={"Authorization": f"Bearer {influxdb_v3_token}"},
-            json=database_creation_body,
-        )
-        try:
-            response.raise_for_status()
-        except HTTPError as e:
-            error_message = f"Failed to create database {database_name}: {e.response}"
-            logger.error(error_message)
-            raise RuntimeError(error_message)
 
     process_name = current_process().name
     total_lines = 0
     line_count = 0
 
-    with InfluxDBClient3(
-        host=influxdb_v3_url, token=influxdb_v3_token, database=database_name
-    ) as client:
+    args = {"host": url, "token": token, "database": database_or_bucket_name}
+    if org is not None:
+        args["org"] = org
+
+    with InfluxDBClient3(**args) as client:
+        # For InfluxDB v2, the bucket must be created prior to ingestion. For InfluxDB v3,
+        # databases are created automatically upon ingestion.
+        server_version = client.get_server_version()
+        logger.info(f"Server version: {server_version}")
+
+        # InfluxDB v2 server versions can vary. These are all v2 "versions" encountered during testing.
+        if (
+            not server_version
+            or server_version == "dev"
+            or server_version.startswith("2")
+            or server_version.startswith("v2")
+        ):
+            logger.info(f"Creating new bucket {database_or_bucket_name} in org {org}")
+            headers = {"Authorization": f"Token {token}"}
+            logger.info("Getting org ID")
+            org_response = requests.get(
+                url=f"{url}/api/v2/orgs", params={"org": org}, headers=headers
+            )
+            org_response.raise_for_status()
+            org_id: str = org_response.json()["orgs"][0]["id"]
+            logger.info(f"Org ID: {org_id}")
+            body = {"name": database_or_bucket_name, "orgID": org_id}
+            if retention_period is not None:
+                body["retentionRules"] = retention_period
+            bucket_creation_response = requests.post(
+                url=f"{url}/api/v2/buckets", headers=headers, json=body
+            )
+            if (
+                bucket_creation_response.status_code != 200
+                and bucket_creation_response.status_code != 201
+                and bucket_creation_response.status_code != 422
+            ):
+                raise RuntimeError(
+                    f"Failed to create bucket {database_or_bucket_name} in {url}"
+                )
+            logger.info("Created bucket")
+
         logger.info(f"Ingesting contents of {str(lp_file_path)}")
         with open(lp_file_path, "r", encoding="utf-8") as file_reader:
             while True:
@@ -364,7 +373,7 @@ def ingest_line_protocol_file(
                 )
                 total_lines += lines_ingested
 
-    return f"Ingested {total_lines} into {database_name}"
+    return f"Ingested {total_lines} into {database_or_bucket_name}"
 
 
 def main(input_args: list[str]) -> int:
@@ -372,8 +381,8 @@ def main(input_args: list[str]) -> int:
         description="Ingest line protocol files from an InfluxDB v2 engine directory into InfluxDB v3 using multiple processes."
     )
     _ = parser.add_argument(
-        "--influxdb-v3-url",
-        help="The InfluxDB v3 URL to ingest data into. Example: 'https://example.com:8181'.",
+        "--url",
+        help="The InfluxDB v2 or v3 URL to ingest data into. Example: 'https://example.com:8181'.",
     )
     _ = parser.add_argument(
         "--tokens-secret-name",
@@ -412,9 +421,9 @@ def main(input_args: list[str]) -> int:
         help="Maximum number of retry attempts for failed batches (default: 20)",
     )
     _ = parser.add_argument(
-        "--influxdb-v2-buckets-and-ids",
+        "--source-buckets-and-ids",
         help=(
-            "A list of bucket names paired with their IDs. "
+            "A list of source bucket names paired with their IDs. "
             "Example: 'bucket-one:12fzmskpe435,bucket-two:shmflq24jaml3'. The separators used in this "
             "list can be changed with the --bucket-separator and --bucket-id-separator arguments."
         ),
@@ -452,6 +461,12 @@ def main(input_args: list[str]) -> int:
         required=False,
         help="The AWS region to use for AWS Secrets Manager.",
     )
+    _ = parser.add_argument(
+        "--destination-org",
+        required=False,
+        default="organization",
+        help=("The InfluxDB v2 organization name to use."),
+    )
 
     args = parser.parse_args(input_args)
     tokens_secret_name: str = args.tokens_secret_name
@@ -461,8 +476,8 @@ def main(input_args: list[str]) -> int:
         tokens: dict[str, str] = utils.get_secret(
             secret_name=tokens_secret_name, region_name=region_name
         )
-        influxdb_v3_token: str | None = tokens.get("INFLUXDB_V3_TOKEN")
-        assert influxdb_v3_token is not None
+        token: str | None = tokens.get("DESTINATION_TOKEN")
+        assert token is not None
 
         logger.info(
             f"Successfully retrieved tokens from Secrets Manager: {tokens_secret_name}"
@@ -473,19 +488,18 @@ def main(input_args: list[str]) -> int:
 
     backup_path = Path(args.backup_path).expanduser()
 
-    print(args.influxdb_v2_buckets_and_ids)
-
     bucket_id_pairs: list[tuple[str, str]] = [
         (bucket_name, bucket_id)
         for bucket_name, bucket_id in (
             pair.split(args.bucket_id_separator, 1)
-            for pair in args.influxdb_v2_buckets_and_ids.split(args.bucket_separator)
+            for pair in args.source_buckets_and_ids.split(args.bucket_separator)
         )
     ]
 
     ingestion_result = ingest_line_protocol_files(
-        args.influxdb_v3_url,
-        influxdb_v3_token,
+        args.url,
+        token,
+        args.destination_org,
         backup_path,
         bucket_id_pairs,
         args.lines,

--- a/tools/python/influxdb_v2_to_v3_migration/tests/integration/test_influxdb_v2_to_v2_migration.py
+++ b/tools/python/influxdb_v2_to_v3_migration/tests/integration/test_influxdb_v2_to_v2_migration.py
@@ -1,6 +1,5 @@
 from typing import Any
 import pytest
-from datetime import datetime, timezone
 import json
 import os
 import re
@@ -13,13 +12,10 @@ import tempfile
 import logging
 
 import boto3
-import httpx
 from influxdb_client.client.organizations_api import OrganizationsApi
 from influxdb_client.client.influxdb_client import InfluxDBClient
-from influxdb_client_3 import InfluxDBClient3
 from testcontainers.core.wait_strategies import LogMessageWaitStrategy
 from testcontainers.influxdb2 import InfluxDb2Container
-from testcontainers.core.container import DockerContainer, ExecResult
 
 sys.path.insert(0, os.path.abspath(os.path.join(os.path.dirname(__file__), "../../")))
 
@@ -31,26 +27,27 @@ DEFAULT_RECORD_NUMBER: int = 10000
 DEFAULT_MEASUREMENT_NAME: str = "testMeasurement"
 
 
-class V2ToV3MigrationTestCase(unittest.TestCase):
+class V2toV2MigrationTestCase(unittest.TestCase):
     """
     Tests for the influxdb_v2_to_v3_migration.py script.
 
-    This test suite verifies migrations end to end, from InfluxDB v2 to v3.
+    This test suite verifies migrations end to end, from InfluxDB v2 to v2:.
     """
 
-    influxdb_v2_container: InfluxDb2Container
-    influxdb_v2_token: str = "test-token"
-    influxdb_v2_url: str = "http://localhost:8087"
+    source_container: InfluxDb2Container
+    source_token: str = "test-token"
+    source_url: str = "http://localhost:8087"
 
-    influxdb_v2_bucket_name_prefix = "v2-to-v3-bucket-"
+    influxdb_v2_bucket_name_prefix = "v2-to-v2-bucket-"
 
-    influxdb_v3_container: DockerContainer
-    influxdb_v3_token: str
-    influxdb_v3_url: str = "http://localhost:8183"
+    destination_container: InfluxDb2Container
+    destination_token: str = "test-token"
+    destination_url: str = "http://localhost:8088"
+    destination_org_name: str = "test-organization"
 
     backup_path: tempfile.TemporaryDirectory
 
-    tokens_secret_name: str = "v2-to-v3-integration-test-secret"
+    tokens_secret_name: str = "v2-to-v2-migration-automation-integration-test-secret"
 
     session: boto3.Session
     secrets_manager_client: Any
@@ -63,8 +60,8 @@ class V2ToV3MigrationTestCase(unittest.TestCase):
         Overrides unittest.TestCase.setUpClass, called once before any
         tests in the class.
         """
-        # InfluxDB v2 setup.
-        cls.influxdb_v2_container: InfluxDb2Container = (
+        # Source setup.
+        cls.source_container: InfluxDb2Container = (
             InfluxDb2Container(
                 "influxdb:2.7",
                 container_port=8086,
@@ -74,7 +71,7 @@ class V2ToV3MigrationTestCase(unittest.TestCase):
                 password="test-password",
                 org_name=INFLUXDB_V2_DEFAULT_ORG_NAME,
                 bucket="test-bucket",
-                admin_token=cls.influxdb_v2_token,
+                admin_token=cls.source_token,
             )
             .waiting_for(LogMessageWaitStrategy(re.compile(r".*msg=Listening.*")))
             .start()
@@ -82,74 +79,41 @@ class V2ToV3MigrationTestCase(unittest.TestCase):
 
         with InfluxDBClient(
             url="http://localhost:8087",
-            token=cls.influxdb_v2_token,
+            token=cls.source_token,
             org=INFLUXDB_V2_DEFAULT_ORG_NAME,
         ) as influxdb_v2_client:
-            influxdb_v2_health_check: bool = influxdb_v2_client.ping()
-            if not influxdb_v2_health_check:
+            if not influxdb_v2_client.ping():
                 raise ConnectionError(
-                    f"setUpClass: Failed to connect to InfluxDB v2 at {cls.influxdb_v2_url}"
+                    f"setUpClass: Failed to connect to InfluxDB v2 at {cls.source_url}"
                 )
 
             orgs_api: OrganizationsApi = influxdb_v2_client.organizations_api()
             _ = orgs_api.create_organization(name=INFLUXDB_V2_SECONDARY_ORG_NAME)
 
-        # InfluxDB v3 core setup.
-        cls.influxdb_v3_container: DockerContainer = (
-            DockerContainer(
-                image="influxdb:3-core",
-                ports=[8181],
-                command="influxdb3 serve --node-id=my-node-0 --object-store=file --data-dir=/var/lib/influxdb3/data",
+        cls.destination_container: InfluxDb2Container = (
+            InfluxDb2Container(
+                "influxdb:2.7",
+                container_port=8086,
+                host_port=8088,
+                init_mode="setup",
+                username="root",
+                password="test-password",
+                org_name=cls.destination_org_name,
+                bucket="test-bucket",
+                admin_token=cls.destination_token,
             )
-            .waiting_for(LogMessageWaitStrategy(re.compile(".*startup time.*")))
-            .with_bind_ports(container="8181/tcp", host=8183)
+            .waiting_for(LogMessageWaitStrategy(re.compile(r".*msg=Listening.*")))
             .start()
         )
 
-        token_creation_result: ExecResult = cls.influxdb_v3_container.exec(
-            ["influxdb3", "create", "token", "--admin"]
-        )
-
-        # Instead of simply outputting the token, tokens are included as part of a message
-        # colored with ANSI escape codes. The output must be decoded from UTF-8, the
-        # ANSI escape codes must be removed, and the token must be extracted from the message.
-        ansi_escape = re.compile(r"\x1B(?:[@-Z\\-_]|\[[0-?]*[ -/]*[@-~])")
-
-        decoded_token_creation_output = str(token_creation_result.output, "utf-8")
-        clean_token_creation_output = ansi_escape.sub("", decoded_token_creation_output)
-        token_regex_search = re.search(
-            r"Token:\s*([^\s]+)", clean_token_creation_output
-        )
-        if not token_regex_search:
-            raise RuntimeError(
-                "Unable to extract InfluxDB v3 token from container logs"
-            )
-        cls.influxdb_v3_token = token_regex_search.group(1)
-
-        database_creation_result = cls.influxdb_v3_container.exec(
-            [
-                "influxdb3",
-                "create",
-                "database",
-                "--token",
-                cls.influxdb_v3_token,
-                "test-database",
-            ]
-        )
-        if database_creation_result.exit_code != 0:
-            raise ConnectionError(
-                f"setUpClass: Failed to create InfluxDB v3 at {cls.influxdb_v3_url}"
-            )
-
-        with InfluxDBClient3(
-            host=cls.influxdb_v3_url,
-            token=cls.influxdb_v3_token,
-            database="test-database",
-        ) as influxdb_v3_client:
-            influxdb_v3_health_check: str = influxdb_v3_client.get_server_version()
-            if not influxdb_v3_health_check:
+        with InfluxDBClient(
+            url="http://localhost:8088",
+            token=cls.destination_token,
+            org=cls.destination_org_name,
+        ) as influxdb_v2_client:
+            if not influxdb_v2_client.ping():
                 raise ConnectionError(
-                    f"setUpClass: Failed to connect to InfluxDB v3 at {cls.influxdb_v3_url}"
+                    f"setUpClass: Failed to connect to InfluxDB v2 at {cls.destination_url}"
                 )
 
         cls.session = boto3.Session()
@@ -158,8 +122,8 @@ class V2ToV3MigrationTestCase(unittest.TestCase):
             Name=cls.tokens_secret_name,
             SecretString=json.dumps(
                 {
-                    "SOURCE_TOKEN": cls.influxdb_v2_token,
-                    "DESTINATION_TOKEN": cls.influxdb_v3_token,
+                    "SOURCE_TOKEN": cls.source_token,
+                    "DESTINATION_TOKEN": cls.destination_token,
                 }
             ),
         )
@@ -187,7 +151,7 @@ class V2ToV3MigrationTestCase(unittest.TestCase):
         Overrides unittest.TestCase.tearDownClass, called after all tests have finished.
         """
         try:
-            cls.influxdb_v2_container.stop(force=True, delete_volume=True)
+            cls.source_container.stop(force=True, delete_volume=True)
         except Exception as e:
             if not cls.suppress_teardown_warnings:
                 logging.warning(
@@ -195,7 +159,7 @@ class V2ToV3MigrationTestCase(unittest.TestCase):
                 )
 
         try:
-            cls.influxdb_v3_container.stop(force=True, delete_volume=True)
+            cls.destination_container.stop(force=True, delete_volume=True)
         except Exception as e:
             if not cls.suppress_teardown_warnings:
                 logging.warning(
@@ -220,7 +184,7 @@ class V2ToV3MigrationTestCase(unittest.TestCase):
         for bucket_name, org_name in self.bucket_org_pairs:
             try:
                 with InfluxDBClient(
-                    url=self.influxdb_v2_url, token=self.influxdb_v2_token, org=org_name
+                    url=self.source_url, token=self.source_token, org=org_name
                 ) as influxdb_v2_client:
                     influxdb_bucket = (
                         influxdb_v2_client.buckets_api().find_bucket_by_name(
@@ -238,23 +202,27 @@ class V2ToV3MigrationTestCase(unittest.TestCase):
                         f"tearDown: Failed to delete InfluxDB v2 bucket: {e}"
                     )
 
+        for bucket_name, _ in self.bucket_org_pairs:
             try:
-                deletion_date = datetime.now(timezone.utc).strftime(
-                    "%Y-%m-%dT%H:%M:%SZ"
-                )
-                deletion_response = httpx.delete(
-                    url=f"{self.influxdb_v3_url}/api/v3/configure/database",
-                    headers={"Authorization": f"Bearer {self.influxdb_v3_token}"},
-                    params={
-                        "db": bucket_name.replace("_", "-"),
-                        "hard_delete_at": deletion_date,
-                    },
-                )
-                _ = deletion_response.raise_for_status()
+                with InfluxDBClient(
+                    url=self.destination_url,
+                    token=self.destination_token,
+                    org=self.destination_org_name,
+                ) as influxdb_v2_client:
+                    influxdb_bucket = (
+                        influxdb_v2_client.buckets_api().find_bucket_by_name(
+                            bucket_name
+                        )
+                    )
+                    if not influxdb_bucket:
+                        raise RuntimeError(
+                            f"tearDown: Failed to find bucket {bucket_name}"
+                        )
+                    influxdb_v2_client.buckets_api().delete_bucket(influxdb_bucket)
             except Exception as e:
                 if not self.suppress_teardown_warnings:
                     logging.warning(
-                        f"tearDown: Failed to delete InfluxDB v3 database: {e}"
+                        f"tearDown: Failed to delete InfluxDB v2 bucket: {e}"
                     )
 
     @staticmethod
@@ -287,7 +255,7 @@ class V2ToV3MigrationTestCase(unittest.TestCase):
             None
         """
         with InfluxDBClient(
-            url=self.influxdb_v2_url, token=self.influxdb_v2_token, org=org_name
+            url=self.source_url, token=self.source_token, org=org_name
         ) as influxdb_v2_client:
             buckets_api = influxdb_v2_client.buckets_api()
 
@@ -307,21 +275,25 @@ class V2ToV3MigrationTestCase(unittest.TestCase):
                 write_api.write(record=record, bucket=bucket_name, org=org_name)
 
     def check_inflxudb_v2_bucket_count(
-        self, bucket_name: str, org_name: str = INFLUXDB_V2_DEFAULT_ORG_NAME
+        self,
+        url: str,
+        token: str,
+        bucket_name: str,
+        org_name: str = INFLUXDB_V2_DEFAULT_ORG_NAME,
     ) -> int:
         """
         Queries the count of points in a bucket.
 
         Args:
+            url (str): The URL to use for queries, including scheme and port.
+            token (str): The InfluxDB v2 or v3 token to use for the query.
             bucket_name (str): Name of the bucket to query.
             org_name (str): The name of the organization in which the bucket belongs.
 
         Returns:
             int: The count of points.
         """
-        with InfluxDBClient(
-            url=self.influxdb_v2_url, token=self.influxdb_v2_token, org=org_name
-        ) as client:
+        with InfluxDBClient(url=url, token=token, org=org_name) as client:
             query_api = client.query_api()
             query = f"""
             from(bucket: "{bucket_name}")
@@ -331,58 +303,6 @@ class V2ToV3MigrationTestCase(unittest.TestCase):
             print("Executing InfluxDB v2 validation query")
             query_result = query_api.query(query)
             return len(query_result.to_values())
-
-    def check_influxdb_v3_table_count(
-        self, database_name: str, table_name: str = DEFAULT_MEASUREMENT_NAME
-    ) -> int:
-        """
-        Queries the number of records in an InfluxDB v3 table.
-
-        Args:
-            database_name (str): The name of the database in which the table resides.
-            table_name (str): The table name to query.
-
-        Returns:
-            int: The number of records in the table.
-        """
-        with InfluxDBClient3(
-            host=self.influxdb_v3_url,
-            token=self.influxdb_v3_token,
-            database=database_name,
-        ) as influxdb_v3_client:
-            query_str = f'SELECT COUNT(*) AS row_count FROM "{table_name}"'
-            print("Executing InfluxDB v3 validation query")
-            results = influxdb_v3_client.query(query_str)
-            return results.column("row_count")[0].as_py()
-
-    def test_migration_basic(self):
-        """
-        Tests basic migration of a single bucket.
-        """
-        return_code = influxdb_v2_to_v3_migration.main(
-            [
-                "--source-url",
-                self.influxdb_v2_url,
-                "--destination-url",
-                self.influxdb_v3_url,
-                "--source-buckets-and-orgs",
-                f"{self.bucket_org_pairs[0][0]}:{INFLUXDB_V2_DEFAULT_ORG_NAME}",
-                "--tokens-secret-name",
-                self.tokens_secret_name,
-                "--backup-path-root",
-                self.backup_path.name,
-            ]
-        )
-
-        database_name = self.bucket_org_pairs[0][0].replace("_", "-")
-
-        self.assertEqual(return_code, 0)
-        self.assertEqual(
-            self.check_inflxudb_v2_bucket_count(
-                bucket_name=self.bucket_org_pairs[0][0]
-            ),
-            self.check_influxdb_v3_table_count(database_name=database_name),
-        )
 
     def test_migration_two_buckets_same_org(self):
         """
@@ -399,9 +319,11 @@ class V2ToV3MigrationTestCase(unittest.TestCase):
         return_code = influxdb_v2_to_v3_migration.main(
             [
                 "--source-url",
-                self.influxdb_v2_url,
+                self.source_url,
                 "--destination-url",
-                self.influxdb_v3_url,
+                self.destination_url,
+                "--destination-org",
+                self.destination_org_name,
                 "--source-buckets-and-orgs",
                 f"{self.bucket_org_pairs[0][0]}:{INFLUXDB_V2_DEFAULT_ORG_NAME},{self.bucket_org_pairs[1][0]}:{INFLUXDB_V2_DEFAULT_ORG_NAME}",
                 "--tokens-secret-name",
@@ -413,10 +335,19 @@ class V2ToV3MigrationTestCase(unittest.TestCase):
 
         self.assertEqual(return_code, 0)
         for bucket_name, org_name in self.bucket_org_pairs:
-            database_name = bucket_name.replace("_", "-")
             self.assertEqual(
-                self.check_inflxudb_v2_bucket_count(bucket_name, org_name),
-                self.check_influxdb_v3_table_count(database_name),
+                self.check_inflxudb_v2_bucket_count(
+                    url=self.source_url,
+                    token=self.source_token,
+                    bucket_name=bucket_name,
+                    org_name=org_name,
+                ),
+                self.check_inflxudb_v2_bucket_count(
+                    url=self.destination_url,
+                    token=self.destination_token,
+                    bucket_name=bucket_name,
+                    org_name=self.destination_org_name,
+                ),
             )
 
     def test_migration_two_buckets_different_orgs(self):
@@ -436,9 +367,11 @@ class V2ToV3MigrationTestCase(unittest.TestCase):
         return_code = influxdb_v2_to_v3_migration.main(
             [
                 "--source-url",
-                self.influxdb_v2_url,
+                self.source_url,
                 "--destination-url",
-                self.influxdb_v3_url,
+                self.destination_url,
+                "--destination-org",
+                self.destination_org_name,
                 "--source-buckets-and-orgs",
                 f"{self.bucket_org_pairs[0][0]}:{INFLUXDB_V2_DEFAULT_ORG_NAME},{self.bucket_org_pairs[1][0]}:{INFLUXDB_V2_SECONDARY_ORG_NAME}",
                 "--tokens-secret-name",
@@ -450,10 +383,19 @@ class V2ToV3MigrationTestCase(unittest.TestCase):
 
         self.assertEqual(return_code, 0)
         for bucket_name, org_name in self.bucket_org_pairs:
-            database_name = bucket_name.replace("_", "-")
             self.assertEqual(
-                self.check_inflxudb_v2_bucket_count(bucket_name, org_name),
-                self.check_influxdb_v3_table_count(database_name),
+                self.check_inflxudb_v2_bucket_count(
+                    url=self.source_url,
+                    token=self.source_token,
+                    bucket_name=bucket_name,
+                    org_name=org_name,
+                ),
+                self.check_inflxudb_v2_bucket_count(
+                    url=self.destination_url,
+                    token=self.destination_token,
+                    bucket_name=bucket_name,
+                    org_name=self.destination_org_name,
+                ),
             )
 
     def test_migration_two_orgs(self):
@@ -474,9 +416,11 @@ class V2ToV3MigrationTestCase(unittest.TestCase):
         return_code = influxdb_v2_to_v3_migration.main(
             [
                 "--source-url",
-                self.influxdb_v2_url,
+                self.source_url,
                 "--destination-url",
-                self.influxdb_v3_url,
+                self.destination_url,
+                "--destination-org",
+                self.destination_org_name,
                 "--source-orgs",
                 f"{INFLUXDB_V2_DEFAULT_ORG_NAME},{INFLUXDB_V2_SECONDARY_ORG_NAME}",
                 "--tokens-secret-name",
@@ -488,10 +432,19 @@ class V2ToV3MigrationTestCase(unittest.TestCase):
 
         self.assertEqual(return_code, 0)
         for bucket_name, org_name in self.bucket_org_pairs:
-            database_name = bucket_name.replace("_", "-")
             self.assertEqual(
-                self.check_inflxudb_v2_bucket_count(bucket_name, org_name),
-                self.check_influxdb_v3_table_count(database_name),
+                self.check_inflxudb_v2_bucket_count(
+                    url=self.source_url,
+                    token=self.source_token,
+                    bucket_name=bucket_name,
+                    org_name=org_name,
+                ),
+                self.check_inflxudb_v2_bucket_count(
+                    url=self.destination_url,
+                    token=self.destination_token,
+                    bucket_name=bucket_name,
+                    org_name=self.destination_org_name,
+                ),
             )
 
     def test_migration_mutually_exclusive_arguments(self):
@@ -513,9 +466,11 @@ class V2ToV3MigrationTestCase(unittest.TestCase):
             influxdb_v2_to_v3_migration.main(
                 [
                     "--source-url",
-                    self.influxdb_v2_url,
+                    self.source_url,
                     "--destination-url",
-                    self.influxdb_v3_url,
+                    self.destination_url,
+                    "--destination-org",
+                    self.destination_org_name,
                     "--source-orgs",
                     f"{INFLUXDB_V2_DEFAULT_ORG_NAME},{INFLUXDB_V2_SECONDARY_ORG_NAME}",
                     "--source-buckets-and-orgs",
@@ -545,9 +500,11 @@ class V2ToV3MigrationTestCase(unittest.TestCase):
         return_code = influxdb_v2_to_v3_migration.main(
             [
                 "--source-url",
-                self.influxdb_v2_url,
+                self.source_url,
                 "--destination-url",
-                self.influxdb_v3_url,
+                self.destination_url,
+                "--destination-org",
+                self.destination_org_name,
                 "--bucket-org-separator",
                 "?",
                 "--bucket-separator",
@@ -563,10 +520,19 @@ class V2ToV3MigrationTestCase(unittest.TestCase):
 
         self.assertEqual(return_code, 0)
         for bucket_name, org_name in self.bucket_org_pairs:
-            database_name = bucket_name.replace("_", "-")
             self.assertEqual(
-                self.check_inflxudb_v2_bucket_count(bucket_name, org_name),
-                self.check_influxdb_v3_table_count(database_name),
+                self.check_inflxudb_v2_bucket_count(
+                    url=self.source_url,
+                    token=self.source_token,
+                    bucket_name=bucket_name,
+                    org_name=org_name,
+                ),
+                self.check_inflxudb_v2_bucket_count(
+                    url=self.destination_url,
+                    token=self.destination_token,
+                    bucket_name=bucket_name,
+                    org_name=self.destination_org_name,
+                ),
             )
 
 


### PR DESCRIPTION
*Issue #, if available:*

N/A.

*Description of changes:*

This PR adds the ability to migrate to InfluxDB v2. Users must provide the argument `--destination-org` to do the migration.

Additionally:
- A new integration test suite for InfluxDB v2 to v2 migrations has been added.
- CLI arguments have been renamed to not be so specific to InfluxDB versions.
- Documentation has been updated for v2 to v2 migrations.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
