### PR TITLE
Fix resume behaviour

### DIFF
--- a/tools/python/liveanalytics_influxdb3_migration_plugin/liveanalytics_migration_client/liveanalytics_influxdb3_migration_client.py
+++ b/tools/python/liveanalytics_influxdb3_migration_plugin/liveanalytics_migration_client/liveanalytics_influxdb3_migration_client.py
@@ -24,7 +24,7 @@ from datetime import datetime, timezone
 
 MIGRATION_METADATA_TABLE: str = "liveanalytics_migration_metadata"
 TRIGGER_NAME: str = "migration_trigger"
-UNLOAD_WAIT_SECONDS: int = 20
+UNLOAD_WAIT_SECONDS: int = 10
 
 
 class InfluxDBMigrationWrapper:
@@ -594,6 +594,9 @@ class InfluxDBMigrationWrapper:
                 self.error(f"Error creating database: ", str(e))
                 return False
 
+            if not self.resume_migration:
+                self.delete_metadata_table(silence_errors=True)
+
             # Create metadata table with 1h retention period.
             self.info(f"Creating {MIGRATION_METADATA_TABLE} table with 1h retention")
             table_url: str = f"{self.influx_host}/api/v3/configure/table"
@@ -690,10 +693,20 @@ class InfluxDBMigrationWrapper:
         session.mount("https://", adapter)
         session.headers.update({"Connection": "keep-alive"})
 
+        url = f"{self.influx_host}/api/v3/engine/{TRIGGER_NAME}"
+        headers = {"Authorization": f"Bearer {self.influx_token}"}
+
+        # For a new migration, delete the trigger cache.
+        if not self.resume_migration:
+            params = {"delete_cache": True}
+            _ = session.post(
+                url=url,
+                headers=headers,
+                params=params,
+                timeout=self.timeout_seconds,
+            )
         try:
             metadata_table_deleted: bool = False
-            url = f"{self.influx_host}/api/v3/engine/{TRIGGER_NAME}"
-            headers = {"Authorization": f"Bearer {self.influx_token}"}
             num_parquet_files_submitted = 0
             for s3_key in metadata:
                 if (
@@ -827,7 +840,7 @@ class InfluxDBMigrationWrapper:
             self.error("Failed to delete processing engine trigger:", str(e))
         return
 
-    def delete_metadata_table(self):
+    def delete_metadata_table(self, silence_errors: bool = False):
         """
         Deletes the InfluxDB v3 migration metadata table.
 
@@ -854,9 +867,10 @@ class InfluxDBMigrationWrapper:
             delete_table_response.raise_for_status()
             self.info(f'Deleted "{self.influx_database}"."{MIGRATION_METADATA_TABLE}"')
         except Exception as e:
-            self.error(
-                f'Failed to delete "{self.liveanalytics_database}"."{MIGRATION_METADATA_TABLE}": {e}'
-            )
+            if not silence_errors:
+                self.error(
+                    f'Failed to delete "{self.liveanalytics_database}"."{MIGRATION_METADATA_TABLE}": {e}'
+                )
 
     def create_processing_engine_trigger(self):
         """

--- a/tools/python/liveanalytics_influxdb3_migration_plugin/liveanalytics_migration_client/liveanalytics_influxdb3_migration_client.py
+++ b/tools/python/liveanalytics_influxdb3_migration_plugin/liveanalytics_migration_client/liveanalytics_influxdb3_migration_client.py
@@ -1051,8 +1051,6 @@ class InfluxDBMigrationWrapper:
         for table_name, manifest_list in self.table_manifests.items():
             total_rows = 0
             for manifest_info in manifest_list:
-                self.info("Manifest info: ")
-                self.info(manifest_info)
                 total_rows += manifest_info.get("total_rows", 0)
             expected_counts[table_name] = total_rows
 
@@ -1068,8 +1066,6 @@ class InfluxDBMigrationWrapper:
         """
         manifest_counts = self.get_expected_row_counts_from_manifests()
         plugin_counts = getattr(self, "expected_table_row_counts", {})
-        self.info("Plugin counts")
-        self.info(plugin_counts)
 
         if not manifest_counts:
             self.warning("No manifest data available for verification")

--- a/tools/python/liveanalytics_influxdb3_migration_plugin/liveanalytics_migration_client/liveanalytics_influxdb3_migration_client.py
+++ b/tools/python/liveanalytics_influxdb3_migration_plugin/liveanalytics_migration_client/liveanalytics_influxdb3_migration_client.py
@@ -141,6 +141,22 @@ class InfluxDBMigrationWrapper:
         for table in tables:
             self.unload_table(table, resume)
 
+            # Set manifest information.
+            manifest_info = self.get_manifest_files(table)
+            if manifest_info:
+                if not hasattr(self, "table_manifests"):
+                    self.table_manifests = {}
+                self.table_manifests[table] = manifest_info
+                file_count = 0
+                row_count = 0
+                for manifest in manifest_info:
+                    file_count += manifest.get("file_count", 0)
+                    row_count += manifest.get("total_rows", 0)
+                self.info(
+                    f"Manifest information for {table}: {file_count} files, "
+                    f"{row_count} rows"
+                )
+
     def unload_table(self, table_name: str, resume: bool = False) -> None:
         """
         Unloads a specific table from Timestream for LiveAnalytics to S3.
@@ -353,25 +369,12 @@ class InfluxDBMigrationWrapper:
                 error_code = e.response.get("Error", {}).get("Code", "")
                 raise RuntimeError(f"UNLOAD chunk failed: {error_code} - {str(e)}")
 
-        # Set manifest information.
-        manifest_info = self.get_manifest_file(table_name)
-        if manifest_info:
-            if not hasattr(self, "table_manifests"):
-                self.table_manifests = {}
-            if table_name not in self.table_manifests:
-                self.table_manifests[table_name] = []
-            self.table_manifests[table_name].append(manifest_info)
-            self.info(
-                f"Chunk {chunk_num} manifest: {manifest_info['file_count']} files, "
-                f"{manifest_info['total_rows']:,} rows"
-            )
-
-    def get_manifest_file(
+    def get_manifest_files(
         self,
         table_name: str,
-    ) -> dict | None:
+    ) -> list[dict] | None:
         """
-        Gets the manifest file for a chunk from S3.
+        Gets the manifest file for a table and each chunk from S3.
         The manifest file contains the complete list of parquet files and row counts.
 
         Args:
@@ -383,7 +386,9 @@ class InfluxDBMigrationWrapper:
         """
         prefix = f"{self.liveanalytics_database}/{table_name}/"
 
-        self.info(f"Getting manifest file for table {table_name}...")
+        self.info(f"Getting manifest files for table {table_name}...")
+
+        manifests = []
 
         try:
             paginator = self.s3_client.get_paginator("list_objects_v2")
@@ -393,13 +398,15 @@ class InfluxDBMigrationWrapper:
                     key = obj.get("Key", "")
                     if "_manifest" in key:
                         self.info(f"Found manifest file: {key}")
-                        return self.parse_manifest_file(key)
+                        manifests.append(self.parse_manifest_file(key))
 
         except Exception as e:
             self.warning(f"Error checking for manifest file: {e}")
 
-        self.error(f"Manifest file not found for table {table_name}")
-        return None
+        if not manifests:
+            self.error(f"Manifest file not found for table {table_name}")
+            return None
+        return manifests
 
     def parse_manifest_file(self, manifest_key: str) -> dict | None:
         """
@@ -1044,6 +1051,8 @@ class InfluxDBMigrationWrapper:
         for table_name, manifest_list in self.table_manifests.items():
             total_rows = 0
             for manifest_info in manifest_list:
+                self.info("Manifest info: ")
+                self.info(manifest_info)
                 total_rows += manifest_info.get("total_rows", 0)
             expected_counts[table_name] = total_rows
 
@@ -1059,6 +1068,8 @@ class InfluxDBMigrationWrapper:
         """
         manifest_counts = self.get_expected_row_counts_from_manifests()
         plugin_counts = getattr(self, "expected_table_row_counts", {})
+        self.info("Plugin counts")
+        self.info(plugin_counts)
 
         if not manifest_counts:
             self.warning("No manifest data available for verification")

--- a/tools/python/liveanalytics_influxdb3_migration_plugin/liveanalytics_migration_client/liveanalytics_influxdb3_migration_client.py
+++ b/tools/python/liveanalytics_influxdb3_migration_plugin/liveanalytics_migration_client/liveanalytics_influxdb3_migration_client.py
@@ -102,7 +102,7 @@ class InfluxDBMigrationWrapper:
     def warning(self, message: str) -> None:
         self.logger.warning(message)
 
-    def unload_db(self) -> None:
+    def unload_db(self, resume: bool = False) -> None:
         """
         Unloads an entire database from Timestream for LiveAnalytics to S3.
 
@@ -136,9 +136,9 @@ class InfluxDBMigrationWrapper:
         self.info(f"Found {len(tables)} tables to unload: {tables}")
 
         for table in tables:
-            self.unload_table(table)
+            self.unload_table(table, resume)
 
-    def unload_table(self, table_name: str) -> None:
+    def unload_table(self, table_name: str, resume: bool = False) -> None:
         """
         Unloads a specific table from Timestream for LiveAnalytics to S3.
         Splits the UNLOAD into multiple queries, each covering at most 99 days
@@ -146,54 +146,67 @@ class InfluxDBMigrationWrapper:
 
         Args:
             table_name (str): Name of the table to unload.
+            resume (bool): Whether a migration is being resumed. If this is
+                True, no UNLOAD queries will be sent.
 
         Returns:
             None
-            
+
         Raises:
             RuntimeError: If UNLOAD fails, indicating partial writes may exist in S3.
         """
-        self.info(f"Unloading table: {table_name}")
-
         try:
             time_range = self.get_table_time_range(table_name)
             if not time_range:
                 self.warning(f"No data found in table {table_name}, skipping UNLOAD")
                 return
-            
+
             min_time, max_time = time_range
             self.info(f"Table {table_name} time range: {min_time} to {max_time}")
-            
+
             # Calculate total days and number of UNLOAD chunks needed
             from datetime import timedelta
+
             total_days = (max_time - min_time).days + 1
             max_days_per_chunk = 99
             num_chunks = (total_days + max_days_per_chunk - 1) // max_days_per_chunk
-            
-            self.info(f"Splitting UNLOAD into {num_chunks} chunk(s)")
-            
+
+            self.info(
+                f"Dataset will be chronologically split into {num_chunks} chunk(s)"
+            )
+
             chunk_start = min_time
             chunk_num = 0
-            
+
             while chunk_start <= max_time:
                 chunk_num += 1
-                chunk_end = min(chunk_start + timedelta(days=max_days_per_chunk - 1), max_time)
-                
+                chunk_end = min(
+                    chunk_start + timedelta(days=max_days_per_chunk - 1), max_time
+                )
+
                 start_str = chunk_start.strftime("%Y-%m-%d 00:00:00")
                 end_str = (chunk_end + timedelta(days=1)).strftime("%Y-%m-%d 00:00:00")
-                
-                self.info(f"UNLOAD chunk {chunk_num}/{num_chunks}: {chunk_start.date()} to {chunk_end.date()}")
-                
-                self.unload_table_chunk(table_name, start_str, end_str, chunk_num)
-                
+
+                self.info(
+                    f"UNLOAD chunk {chunk_num}/{num_chunks}: {chunk_start.date()} to {chunk_end.date()}"
+                )
+
+                self.unload_table_chunk(
+                    table_name, start_str, end_str, chunk_num, resume
+                )
+
                 chunk_start = chunk_end + timedelta(days=1)
-            
-            self.info(f"UNLOAD complete for table {table_name}: {chunk_num} chunk(s) processed")
-            
+
+            self.info(
+                f"UNLOAD complete for table {table_name}: {chunk_num} chunk(s) processed"
+            )
+
         except Exception as e:
-            self.error(f"UNLOAD operation failed for s3://{self.s3_bucket_name}/{self.liveanalytics_database}/{table_name}/")
+            self.error(
+                f"UNLOAD operation failed for s3://{self.s3_bucket_name}/{self.liveanalytics_database}/{table_name}/"
+            )
             self.error(f"Error: {str(e)}")
-            
+
             raise RuntimeError(
                 f"UNLOAD failed for table {table_name}: {str(e)}. "
                 f"Partial writes may exist in S3. Migration cancelled."
@@ -216,32 +229,56 @@ class InfluxDBMigrationWrapper:
                     FROM "{self.liveanalytics_database}"."{table_name}"
                 """
             )
-            
+
+            next_token = response.get("NextToken")
+            while next_token is not None:
+                response = self.timestream_query_client.query(
+                    NextToken=next_token,
+                    QueryString=f"""
+                    SELECT min(time) as min_time, max(time) as max_time 
+                    FROM "{self.liveanalytics_database}"."{table_name}"
+                """,
+                )
+                next_token = response.get("NextToken")
+                time.sleep(UNLOAD_WAIT_SECONDS)
+
             rows = response.get("Rows", [])
             if not rows:
                 return None
-            
+
             row_data = rows[0].get("Data", [])
             if len(row_data) < 2:
                 return None
-            
+
             min_time_str = row_data[0].get("ScalarValue")
             max_time_str = row_data[1].get("ScalarValue")
-            
+
             if not min_time_str or not max_time_str:
                 return None
-            
+
             from datetime import datetime
-            min_time = datetime.fromisoformat(min_time_str.replace(" ", "T").split(".")[0])
-            max_time = datetime.fromisoformat(max_time_str.replace(" ", "T").split(".")[0])
-            
+
+            min_time = datetime.fromisoformat(
+                min_time_str.replace(" ", "T").split(".")[0]
+            )
+            max_time = datetime.fromisoformat(
+                max_time_str.replace(" ", "T").split(".")[0]
+            )
+
             return (min_time, max_time)
-            
+
         except Exception as e:
             self.warning(f"Failed to get time range for table {table_name}: {e}")
             return None
 
-    def unload_table_chunk(self, table_name: str, start_time: str, end_time: str, chunk_num: int) -> None:
+    def unload_table_chunk(
+        self,
+        table_name: str,
+        start_time: str,
+        end_time: str,
+        chunk_num: int,
+        resume: bool = False,
+    ) -> None:
         """
         Unloads a time-bounded chunk of a table to S3 with partition_by day.
         Each chunk writes to a unique path to get its own manifest file.
@@ -251,104 +288,124 @@ class InfluxDBMigrationWrapper:
             start_time (str): Start time (inclusive) in format 'YYYY-MM-DD HH:MM:SS'.
             end_time (str): End time (exclusive) in format 'YYYY-MM-DD HH:MM:SS'.
             chunk_num (int): Chunk number for unique S3 path.
+            resume (bool): Whether a migration is being resumed. If this is True, no UNLOAD
+                queries will be sent.
         """
-        try:
-            chunk_path = f"s3://{self.s3_bucket_name}/{self.liveanalytics_database}/{table_name}/chunk_{chunk_num:03d}"
-            
-            # Use partition_by for smaller files (one per day)
-            response = self.timestream_query_client.query(
-                QueryString=f"""
-                    UNLOAD (
-                        SELECT *, DATE_FORMAT(time, '%y-%m-%d') as partition_date 
-                        FROM "{self.liveanalytics_database}"."{table_name}"
-                        WHERE time >= '{start_time}' AND time < '{end_time}'
-                    ) 
-                    TO '{chunk_path}' 
-                    WITH (partitioned_by = ARRAY['partition_date'], 
-                          format = 'PARQUET', 
-                          max_file_size='16MB', 
-                          compression = 'NONE')
-                    """
-            )
-            
-            http_status = response.get("ResponseMetadata", {}).get("HTTPStatusCode", 0)
-            if http_status < 200 or http_status >= 300:
-                raise RuntimeError(f"UNLOAD chunk returned HTTP {http_status}")
-            
-            self.info(f"UNLOAD chunk completed")
-            
-            # Wait for manifest file and store info
-            manifest_info = self.wait_for_manifest_file(table_name, chunk_num)
-            if manifest_info:
-                if not hasattr(self, 'table_manifests'):
-                    self.table_manifests = {}
-                if table_name not in self.table_manifests:
-                    self.table_manifests[table_name] = []
-                self.table_manifests[table_name].append(manifest_info)
-                self.info(
-                    f"Chunk {chunk_num} manifest: {manifest_info['file_count']} files, "
-                    f"{manifest_info['total_rows']:,} rows"
-                )
-            else:
-                raise RuntimeError(f"Manifest file not found for chunk {chunk_num}")
-            
-        except ClientError as e:
-            error_code = e.response.get("Error", {}).get("Code", "")
-            raise RuntimeError(f"UNLOAD chunk failed: {error_code} - {str(e)}")
+        # Unload from Timestream for LiveAnalytics to S3.
+        if not resume:
+            self.info(f"Unloading table: {table_name}")
+            try:
+                chunk_path = f"s3://{self.s3_bucket_name}/{self.liveanalytics_database}/{table_name}/chunk_{chunk_num:03d}"
 
-    def wait_for_manifest_file(
+                # Use partition_by for smaller files (one per day)
+                response = self.timestream_query_client.query(
+                    QueryString=f"""
+                        UNLOAD (
+                            SELECT *, DATE_FORMAT(time, '%y-%m-%d') as partition_date 
+                            FROM "{self.liveanalytics_database}"."{table_name}"
+                            WHERE time >= '{start_time}' AND time < '{end_time}'
+                        ) 
+                        TO '{chunk_path}' 
+                        WITH (partitioned_by = ARRAY['partition_date'], 
+                              format = 'PARQUET', 
+                              max_file_size='16MB', 
+                              compression = 'NONE')
+                        """
+                )
+
+                http_status = response.get("ResponseMetadata", {}).get(
+                    "HTTPStatusCode", 0
+                )
+                if http_status < 200 or http_status >= 300:
+                    raise RuntimeError(f"UNLOAD chunk returned HTTP {http_status}")
+
+                # Wait for UNLOAD to complete.
+                next_token = response.get("NextToken")
+                while next_token is not None:
+                    # Note: whitespace must match the original query.
+                    response = self.timestream_query_client.query(
+                        NextToken=next_token,
+                        QueryString=f"""
+                        UNLOAD (
+                            SELECT *, DATE_FORMAT(time, '%y-%m-%d') as partition_date 
+                            FROM "{self.liveanalytics_database}"."{table_name}"
+                            WHERE time >= '{start_time}' AND time < '{end_time}'
+                        ) 
+                        TO '{chunk_path}' 
+                        WITH (partitioned_by = ARRAY['partition_date'], 
+                              format = 'PARQUET', 
+                              max_file_size='16MB', 
+                              compression = 'NONE')
+                        """,
+                    )
+                    next_token = response.get("NextToken")
+                    unload_progress = response.get("QueryStatus", {}).get(
+                        "ProgressPercentage"
+                    )
+                    self.info(f"Unload progress: {str(unload_progress)}%")
+                    if unload_progress >= 100.0:
+                        break
+                    time.sleep(UNLOAD_WAIT_SECONDS)
+            except ClientError as e:
+                error_code = e.response.get("Error", {}).get("Code", "")
+                raise RuntimeError(f"UNLOAD chunk failed: {error_code} - {str(e)}")
+
+        # Set manifest information.
+        manifest_info = self.get_manifest_file(table_name)
+        if manifest_info:
+            if not hasattr(self, "table_manifests"):
+                self.table_manifests = {}
+            if table_name not in self.table_manifests:
+                self.table_manifests[table_name] = []
+            self.table_manifests[table_name].append(manifest_info)
+            self.info(
+                f"Chunk {chunk_num} manifest: {manifest_info['file_count']} files, "
+                f"{manifest_info['total_rows']:,} rows"
+            )
+
+    def get_manifest_file(
         self,
         table_name: str,
-        chunk_num: int,
-        poll_interval_seconds: int = 5,
-        max_wait_seconds: int = 300
     ) -> dict | None:
         """
-        Waits for the Timestream UNLOAD manifest file to appear in S3.
+        Gets the manifest file for a chunk from S3.
         The manifest file contains the complete list of parquet files and row counts.
 
         Args:
             table_name (str): Name of the table being unloaded.
             chunk_num (int): Chunk number to find specific manifest.
-            poll_interval_seconds (int): Seconds between S3 checks. Default 5.
-            max_wait_seconds (int): Maximum seconds to wait. Default 300 (5 minutes).
 
         Returns:
             dict: Manifest info with 'file_count', 'total_rows', 'files' or None if not found.
         """
-        manifest_prefix = f"{self.liveanalytics_database}/{table_name}/chunk_{chunk_num:03d}/"
-        elapsed_seconds = 0
-        
-        self.info(f"Waiting for manifest file for table {table_name}...")
-        
-        while elapsed_seconds < max_wait_seconds:
-            try:
-                paginator = self.s3_client.get_paginator("list_objects_v2")
-                
-                for page in paginator.paginate(Bucket=self.s3_bucket_name, Prefix=manifest_prefix):
-                    for obj in page.get("Contents", []):
-                        key = obj.get("Key", "")
-                        if "_manifest" in key:
-                            self.info(f"Found manifest file: {key}")
-                            return self.parse_manifest_file(key)
-                
-                self.info(f"Waiting for manifest file... ({elapsed_seconds}s elapsed)")
-                
-            except Exception as e:
-                self.warning(f"Error checking for manifest file: {e}")
-            
-            time.sleep(poll_interval_seconds)
-            elapsed_seconds += poll_interval_seconds
-        
-        self.warning(
-            f"Manifest file not found for table {table_name} after {max_wait_seconds}s"
+        prefix = (
+            f"{self.liveanalytics_database}/{table_name}/"
         )
+
+        self.info(f"Getting manifest file for table {table_name}...")
+
+        try:
+            paginator = self.s3_client.get_paginator("list_objects_v2")
+
+            for page in paginator.paginate(
+                Bucket=self.s3_bucket_name, Prefix=prefix
+            ):
+                for obj in page.get("Contents", []):
+                    key = obj.get("Key", "")
+                    if "_manifest" in key:
+                        self.info(f"Found manifest file: {key}")
+                        return self.parse_manifest_file(key)
+
+        except Exception as e:
+            self.warning(f"Error checking for manifest file: {e}")
+
+        self.error(f"Manifest file not found for table {table_name}")
         return None
 
     def parse_manifest_file(self, manifest_key: str) -> dict | None:
         """
         Parses the Timestream UNLOAD manifest file to get file list and row counts.
-        
+
         Manifest format:
         {
           "result_files": [
@@ -371,20 +428,22 @@ class InfluxDBMigrationWrapper:
             )
             manifest_content = response["Body"].read().decode("utf-8")
             manifest = json.loads(manifest_content)
-            
+
             result_files = manifest.get("result_files", [])
             query_metadata = manifest.get("query_metadata", {})
             total_rows = query_metadata.get("total_row_count", 0)
-            
+
             if total_rows == 0:
-                raise RuntimeError(f"Failed to get row count for manifest {manifest_key}")
-            
+                raise RuntimeError(
+                    f"Failed to get row count for manifest {manifest_key}"
+                )
+
             return {
                 "file_count": len(result_files),
                 "total_rows": total_rows,
                 "files": result_files,
             }
-            
+
         except Exception as e:
             self.warning(f"Failed to parse manifest file {manifest_key}: {e}")
             return None
@@ -399,24 +458,24 @@ class InfluxDBMigrationWrapper:
         Raises:
             RuntimeError: If no manifest files are available.
         """
-        if not hasattr(self, 'table_manifests') or not self.table_manifests:
+        if not hasattr(self, "table_manifests") or not self.table_manifests:
             raise RuntimeError(
                 "No manifest files found. UNLOAD must complete successfully "
                 "and generate manifest files before migration can proceed."
             )
-        
+
         parquet_keys: list[str] = []
         total_rows = 0
-        
+
         for table_name, manifest_list in self.table_manifests.items():
             table_files = 0
             table_rows = 0
-            
+
             for manifest_info in manifest_list:
                 files = manifest_info.get("files", [])
                 table_files += len(files)
                 table_rows += manifest_info.get("total_rows", 0)
-                
+
                 for file_entry in files:
                     url = file_entry.get("url", "")
                     if url:
@@ -424,16 +483,18 @@ class InfluxDBMigrationWrapper:
                         if len(parts) == 2:
                             s3_key = parts[1]
                             parquet_keys.append(s3_key)
-            
-            self.info(f"Table {table_name}: {table_files} files, {table_rows:,} rows from {len(manifest_list)} chunks")
+
+            self.info(
+                f"Table {table_name}: {table_files} files, {table_rows:,} rows from {len(manifest_list)} chunks"
+            )
             total_rows += table_rows
-        
+
         if not parquet_keys:
             raise RuntimeError(
                 "No parquet files found in manifest files. "
                 "UNLOAD may have produced empty results."
             )
-        
+
         self.info(f"Total: {len(parquet_keys)} parquet files, {total_rows:,} rows")
         return parquet_keys
 
@@ -605,7 +666,6 @@ class InfluxDBMigrationWrapper:
             self.error(f"Failed to write metadata to InfluxDB: ", str(e))
             sys.exit(1)
 
-
     def bulk_invoke_http_trigger(self, metadata):
         """
         Invokes the HTTP migration processing engine trigger for all Parquet files to be migrated.
@@ -617,7 +677,7 @@ class InfluxDBMigrationWrapper:
             None
         """
         session = requests.Session()
-        
+
         adapter = requests.adapters.HTTPAdapter(
             pool_connections=10,
             pool_maxsize=10,
@@ -630,12 +690,12 @@ class InfluxDBMigrationWrapper:
         )
         session.mount("https://", adapter)
         session.headers.update({"Connection": "keep-alive"})
-        
+
         try:
             metadata_table_deleted: bool = False
             url = f"{self.influx_host}/api/v3/engine/{TRIGGER_NAME}"
             headers = {"Authorization": f"Bearer {self.influx_token}"}
-            
+            num_parquet_files_submitted = 0
             for s3_key in metadata:
                 if (
                     self.max_parquet_files is not None
@@ -643,9 +703,11 @@ class InfluxDBMigrationWrapper:
                 ):
                     break
                 table_name = s3_key.split("/")[1]
-                self.info(f'Migrating {s3_key} to "{self.influx_database}"."{table_name}"')
+                self.info(
+                    f'Migrating {s3_key} to "{self.influx_database}"."{table_name}"'
+                )
                 json_body = {"parquet_path": s3_key}
-                
+
                 trigger_invocation_response = session.post(
                     url=url,
                     json=json_body,
@@ -654,10 +716,12 @@ class InfluxDBMigrationWrapper:
                 )
                 trigger_invocation_response.raise_for_status()
                 response_body = trigger_invocation_response.json()
-                
+
                 if response_body["status"] != 200 and response_body["status"] != 202:
-                    raise RuntimeError(f"Migrating {s3_key} failed: {response_body['message']}")
-                    
+                    raise RuntimeError(
+                        f"Migrating {s3_key} failed: {response_body['message']}"
+                    )
+
                 if not metadata_table_deleted:
                     self.delete_metadata_table()
                     metadata_table_deleted = True
@@ -673,15 +737,19 @@ class InfluxDBMigrationWrapper:
             )
             final_invocation_response.raise_for_status()
             response_json = final_invocation_response.json()
-            
+
             if response_json["status"] != 200:
-                raise Exception(f"Final verification failed: {response_json['message']}")
-            
+                raise Exception(
+                    f"Final verification failed: {response_json['message']}"
+                )
+
             # Store expected table row counts for final verification
             self.expected_table_row_counts = response_json.get("table_row_counts", {})
-            
+
         except Exception as e:
-            self.error(f"HTTP invocation failed: {e}. View processing engine logs for more information")
+            self.error(
+                f"HTTP invocation failed: {e}. View processing engine logs for more information"
+            )
             raise
         # Trigger is only deleted when a migration is successful. This allows users to resume a
         # migration if an error occurs.
@@ -857,11 +925,9 @@ class InfluxDBMigrationWrapper:
         if not self.verify_bucket():
             raise RuntimeError("Unable to verify bucket")
 
-        if not self.resume_migration:
-            self.info("Performing Timestream for LiveAnalytics unload operations")
-            self.unload_db()
-        else:
+        if self.resume_migration:
             self.info("Resuming migration and skipping unload operations")
+        self.unload_db(self.resume_migration)
 
         # Get parquet file list from manifest files (generated during each UNLOAD chunk)
         parquet_file_names: list[str] = self.get_parquet_files_from_manifests()
@@ -878,10 +944,10 @@ class InfluxDBMigrationWrapper:
         self.write_metadata_to_influxdb(metadata)
         self.create_processing_engine_trigger()
         self.bulk_invoke_http_trigger(metadata)
-        
+
         # Final verification: compare expected row counts from plugin with actual InfluxDB counts
         self.verify_final_row_counts()
-        
+
         self.delete_unloaded_data()
 
         self.info("Migration wrapper completed successfully")
@@ -951,82 +1017,88 @@ class InfluxDBMigrationWrapper:
     def get_expected_row_counts_from_manifests(self) -> dict:
         """
         Aggregates expected row counts per table from manifest files in S3 bucket from UNLOAD operation.
-        
+
         Returns:
             dict: Table name to expected total row count.
         """
-        if not hasattr(self, 'table_manifests') or not self.table_manifests:
+        if not hasattr(self, "table_manifests") or not self.table_manifests:
             return {}
-        
+
         expected_counts = {}
         for table_name, manifest_list in self.table_manifests.items():
             total_rows = 0
             for manifest_info in manifest_list:
                 total_rows += manifest_info.get("total_rows", 0)
             expected_counts[table_name] = total_rows
-        
+
         return expected_counts
 
     def verify_final_row_counts(self) -> bool:
         """
-        Verifies migration by comparing S3 manifest row counts with
-        plugin ingested row counts.
-        
+        Verifies that all tables in the migrated database have the correct row counts
+        by comparing expected counts from S3 manifest files with actual InfluxDB counts.
+
         Returns:
             bool: True if counts match, False otherwise.
         """
         manifest_counts = self.get_expected_row_counts_from_manifests()
-        plugin_counts = getattr(self, 'expected_table_row_counts', {})
-        
+        plugin_counts = getattr(self, "expected_table_row_counts", {})
+
         if not manifest_counts:
             self.warning("No manifest data available for verification")
             return True
-        
+
         if not plugin_counts:
             self.warning("No plugin row counts available for verification")
             return True
 
         self.info("Comparing unload manifest and ingested plugin row counts")
-        
+
         verification_results = []
         total_manifest = 0
         total_plugin = 0
-        
+
         for table_name, manifest_count in manifest_counts.items():
             plugin_count = plugin_counts.get(table_name, 0)
             total_manifest += manifest_count
             total_plugin += plugin_count
-            
+
             if plugin_count == manifest_count:
                 status = "MATCH"
             elif plugin_count < manifest_count:
                 status = "ROWS_SKIPPED"
             else:
                 status = "DEDUP_NEEDED"
-            
-            verification_results.append({
-                "table": table_name,
-                "manifest": manifest_count,
-                "plugin": plugin_count,
-                "status": status,
-            })
-        
+
+            verification_results.append(
+                {
+                    "table": table_name,
+                    "manifest": manifest_count,
+                    "plugin": plugin_count,
+                    "status": status,
+                }
+            )
+
         self.info(f"{'Table':<40} {'Manifest':>15} {'Ingested':>15} {'Status':>15}")
-        
+
         for r in verification_results:
-            self.info(f"{r['table']:<40} {r['manifest']:>15,} {r['plugin']:>15,} {r['status']:>15}")
-        
+            self.info(
+                f"{r['table']:<40} {r['manifest']:>15,} {r['plugin']:>15,} {r['status']:>15}"
+            )
+
         self.info(f"{'Total':<40} {total_manifest:>15,} {total_plugin:>15,}")
-        
+
         skipped = [r for r in verification_results if r["status"] == "ROWS_SKIPPED"]
         if skipped:
             self.info("Some rows are missing during migration")
             for r in skipped:
                 self.info(f"  {r['table']}: {r['manifest'] - r['plugin']:,} skipped")
-        
+
         dedup = [r for r in verification_results if r["status"] == "DEDUP_NEEDED"]
         if dedup:
-            self.info("Deduplication may be needed as extra row counts were encountered during migration")
+            self.info(
+                "Deduplication may be needed as extra row counts were encountered during migration"
+            )
             for r in dedup:
                 self.info(f"  {r['table']}: {r['plugin'] - r['manifest']:,} extra rows")
 
@@ -1235,4 +1307,3 @@ Examples:
 
 if __name__ == "__main__":
     main(sys.argv[1:])
-

--- a/tools/python/liveanalytics_influxdb3_migration_plugin/liveanalytics_migration_client/liveanalytics_influxdb3_migration_client.py
+++ b/tools/python/liveanalytics_influxdb3_migration_plugin/liveanalytics_migration_client/liveanalytics_influxdb3_migration_client.py
@@ -751,9 +751,11 @@ class InfluxDBMigrationWrapper:
                 f"HTTP invocation failed: {e}. View processing engine logs for more information"
             )
             raise
+        finally:
+            session.close()
+
         # Trigger is only deleted when a migration is successful. This allows users to resume a
         # migration if an error occurs.
-        session.close()
         self.delete_trigger()
 
     def get_num_completed_and_total_parquet_files(self):

--- a/tools/python/liveanalytics_influxdb3_migration_plugin/liveanalytics_migration_client/liveanalytics_influxdb3_migration_client.py
+++ b/tools/python/liveanalytics_influxdb3_migration_plugin/liveanalytics_migration_client/liveanalytics_influxdb3_migration_client.py
@@ -932,26 +932,45 @@ class InfluxDBMigrationWrapper:
 
         return
 
+    def get_expected_row_counts_from_manifests(self) -> dict:
+        """
+        Aggregates expected row counts per table from manifest files in S3 bucket from UNLOAD operation.
+        
+        Returns:
+            dict: Table name to expected total row count.
+        """
+        if not hasattr(self, 'table_manifests') or not self.table_manifests:
+            return {}
+        
+        expected_counts = {}
+        for table_name, manifest_list in self.table_manifests.items():
+            total_rows = 0
+            for manifest_info in manifest_list:
+                total_rows += manifest_info.get("total_rows", 0)
+            expected_counts[table_name] = total_rows
+        
+        return expected_counts
+
     def verify_final_row_counts(self) -> bool:
         """
         Verifies that all tables in the migrated database have the correct row counts
-        by comparing the expected counts from plugin with actual InfluxDB counts.
-        We verify counts returned from plugin as records that contain NaN or Null
-        only values for measures will be ignored and skew the final count.
+        by comparing expected counts from S3 manifest files with actual InfluxDB counts.
         
         Returns:
             bool: True if all tables match, False if any mismatch is found.
         """
-        if not hasattr(self, 'expected_table_row_counts') or not self.expected_table_row_counts:
-            self.warning("No expected table row counts available for verification")
+        expected_counts = self.get_expected_row_counts_from_manifests()
+        
+        if not expected_counts:
+            self.warning("No manifest data available for row count verification")
             return True
         
-        self.info("Final verification to compare row counts")
+        self.info("Comparing manifest table row counts with InfluxDB table rows")
         
         all_verified = True
         verification_results = []
         
-        for table_name, expected_count in self.expected_table_row_counts.items():
+        for table_name, expected_count in expected_counts.items():
             actual_count = None
             try:
                 query_str = f'SELECT COUNT(*) AS row_count FROM "{table_name}"'
@@ -967,9 +986,12 @@ class InfluxDBMigrationWrapper:
                 all_verified = False
             elif actual_count == expected_count:
                 status = "MATCH"
-            else:
-                status = "MISMATCH"
+            elif actual_count < expected_count:
+                status = "DATA_LOSS"
                 all_verified = False
+            else:
+                # More rows than expected - duplicates or overlap
+                status = "EXTRA_ROWS"
             
             verification_results.append({
                 "table": table_name,
@@ -979,27 +1001,37 @@ class InfluxDBMigrationWrapper:
             })
         
         self.info("")
-        self.info(f"{'Table':<40} {'Expected':>15} {'Actual':>15} {'Status':>10}")
+        self.info(f"{'Table':<40} {'Manifest':>15} {'InfluxDB':>15} {'Status':>12}")
         
         for result in verification_results:
             expected = f"{result['expected_count']:,}"
             actual = f"{result['actual_count']:,}" if result['actual_count'] is not None else "ERROR"
-            self.info(f"{result['table']:<40} {expected:>15} {actual:>15} {result['status']:>10}")
+            self.info(f"{result['table']:<40} {expected:>15} {actual:>15} {result['status']:>12}")
         
         
         if all_verified:
-            self.info("All tables verified successfully")
+            self.info("Migration successful, all tables verified")
         else:
-            self.warning("Some tables have mismatched row counts during migration")
+            self.error("Some tables have unexpected row count issues")
             for result in verification_results:
-                if result["status"] == "MISMATCH":
+                if result["status"] == "DATA_LOSS":
+                    diff = (result['expected_count'] or 0) - (result['actual_count'] or 0)
+                    self.error(
+                        f"  DATA LOSS in '{result['table']}': "
+                        f"Manifest={result['expected_count']:,}, "
+                        f"InfluxDB={result['actual_count']:,}, "
+                        f"Missing={diff:,} rows"
+                    )
+                elif result["status"] == "EXTRA_ROWS":
                     diff = (result['actual_count'] or 0) - (result['expected_count'] or 0)
                     self.warning(
-                        f"  Table '{result['table']}': "
-                        f"Expected={result['expected_count']}, "
-                        f"Actual={result['actual_count']}, "
-                        f"Difference={diff:+d}"
+                        f"  EXTRA ROWS in '{result['table']}': "
+                        f"Manifest={result['expected_count']:,}, "
+                        f"InfluxDB={result['actual_count']:,}, "
+                        f"Extra={diff:,} rows (may be from overlapping time ranges)"
                     )
+                elif result["status"] == "ERROR":
+                    self.error(f"  ERROR querying '{result['table']}'")
         
         return all_verified
 

--- a/tools/python/liveanalytics_influxdb3_migration_plugin/liveanalytics_migration_client/liveanalytics_influxdb3_migration_client.py
+++ b/tools/python/liveanalytics_influxdb3_migration_plugin/liveanalytics_migration_client/liveanalytics_influxdb3_migration_client.py
@@ -595,64 +595,6 @@ class InfluxDBMigrationWrapper:
             self.error(f"Failed to write metadata to InfluxDB: ", str(e))
             sys.exit(1)
 
-    def get_s3_objects_list(
-        self, wait_period_seconds=20, max_wait_seconds=1_800
-    ) -> list[str]:
-        """
-        Gets a list of parquet files in an S3 bucket by scanning S3.
-
-        Returns:
-            list[str]: List of parquet file keys
-        """
-
-        parquet_keys: set[str] = set()
-        processed_keys: set[str] = set()
-        files_to_migrate: set[str] = set()
-
-        total_wait_seconds = 0
-        while total_wait_seconds < max_wait_seconds:
-            try:
-                # Use paginator to handle large buckets.
-                paginator = self.s3_client.get_paginator("list_objects_v2")
-                page_iterator = paginator.paginate(
-                    Bucket=self.s3_bucket_name, Prefix=self.liveanalytics_database
-                )
-
-                for page in page_iterator:
-                    for obj in page.get("Contents", []):
-                        key = obj.get("Key")
-                        if not key:
-                            continue
-                        if key.endswith(".parquet"):
-                            parquet_keys.add(key)
-                        if key.endswith("done.ack"):
-                            processed_keys.add(key.replace("/done.ack", ""))
-                files_to_migrate = parquet_keys - processed_keys
-
-            except ClientError as e:
-                error_code: str = e.response.get("Error", {}).get("Code", "")
-                if error_code == "NoSuchBucket":
-                    self.error(f"Error: Bucket {self.s3_bucket_name} does not exist.")
-                elif error_code == "AccessDenied":
-                    self.error(f"Error: Access denied to bucket {self.s3_bucket_name}.")
-                else:
-                    self.error(f"Error listing objects in bucket {self.s3_bucket_name}: {str(e)}")
-                return []
-            except Exception as e:
-                self.error(f"Unexpected error while listing objects: {str(e)}")
-                return []
-
-            if len(files_to_migrate) == 0:
-                if total_wait_seconds + wait_period_seconds >= max_wait_seconds:
-                    raise RuntimeError(f"No Parquet files found in {self.s3_bucket_name}")
-                self.warning(f"No parquet files found in bucket {self.s3_bucket_name}. Retrying")
-                total_wait_seconds += wait_period_seconds
-                time.sleep(wait_period_seconds)
-            else:
-                break
-
-        self.info(f"Found {len(files_to_migrate)} parquet files to migrate")
-        return list(files_to_migrate)
 
     def bulk_invoke_http_trigger(self, metadata):
         """

--- a/tools/python/liveanalytics_influxdb3_migration_plugin/liveanalytics_migration_client/liveanalytics_influxdb3_migration_client.py
+++ b/tools/python/liveanalytics_influxdb3_migration_plugin/liveanalytics_migration_client/liveanalytics_influxdb3_migration_client.py
@@ -96,6 +96,9 @@ class InfluxDBMigrationWrapper:
     def info(self, message: str) -> None:
         self.logger.info(message)
 
+    def debug(self, message: str) -> None:
+        self.logger.debug(message)
+
     def error(self, message: str, error_details: str = "") -> None:
         self.logger.error(f"{message} {error_details}")
 
@@ -378,18 +381,14 @@ class InfluxDBMigrationWrapper:
         Returns:
             dict: Manifest info with 'file_count', 'total_rows', 'files' or None if not found.
         """
-        prefix = (
-            f"{self.liveanalytics_database}/{table_name}/"
-        )
+        prefix = f"{self.liveanalytics_database}/{table_name}/"
 
         self.info(f"Getting manifest file for table {table_name}...")
 
         try:
             paginator = self.s3_client.get_paginator("list_objects_v2")
 
-            for page in paginator.paginate(
-                Bucket=self.s3_bucket_name, Prefix=prefix
-            ):
+            for page in paginator.paginate(Bucket=self.s3_bucket_name, Prefix=prefix):
                 for obj in page.get("Contents", []):
                     key = obj.get("Key", "")
                     if "_manifest" in key:
@@ -745,6 +744,7 @@ class InfluxDBMigrationWrapper:
 
             # Store expected table row counts for final verification
             self.expected_table_row_counts = response_json.get("table_row_counts", {})
+            self.debug(f"Invocation response: {response_json}")
 
         except Exception as e:
             self.error(

--- a/tools/python/liveanalytics_influxdb3_migration_plugin/liveanalytics_migration_client/liveanalytics_influxdb3_migration_client.py
+++ b/tools/python/liveanalytics_influxdb3_migration_plugin/liveanalytics_migration_client/liveanalytics_influxdb3_migration_client.py
@@ -822,7 +822,14 @@ class InfluxDBMigrationWrapper:
                 num_parquet_files_submitted += 1
 
             # Final verification invocation.
-            verification_params = {"verify": True, "delete_cache": True}
+            is_partial_migration = (
+                self.max_parquet_files is not None
+                and self.max_parquet_files < len(metadata)
+            )
+            if is_partial_migration:
+                verification_params = {"verify": True}
+            else:
+                verification_params = {"verify": True, "delete_cache": True}
             final_invocation_response = session.post(
                 url=url,
                 headers=headers,

--- a/tools/python/liveanalytics_influxdb3_migration_plugin/liveanalytics_migration_client/liveanalytics_influxdb3_migration_client.py
+++ b/tools/python/liveanalytics_influxdb3_migration_plugin/liveanalytics_migration_client/liveanalytics_influxdb3_migration_client.py
@@ -135,112 +135,307 @@ class InfluxDBMigrationWrapper:
     def unload_table(self, table_name: str) -> None:
         """
         Unloads a specific table from Timestream for LiveAnalytics to S3.
+        Splits the UNLOAD into multiple queries, each covering at most 99 days
+        to avoid the 100 partition limit with partition_by.
 
         Args:
             table_name (str): Name of the table to unload.
 
         Returns:
             None
+            
+        Raises:
+            RuntimeError: If UNLOAD fails, indicating partial writes may exist in S3.
         """
         self.info(f"Unloading table: {table_name}")
 
         try:
-            _ = self.timestream_query_client.query(
+            time_range = self.get_table_time_range(table_name)
+            if not time_range:
+                self.warning(f"No data found in table {table_name}, skipping UNLOAD")
+                return
+            
+            min_time, max_time = time_range
+            self.info(f"Table {table_name} time range: {min_time} to {max_time}")
+            
+            # Calculate total days and number of UNLOAD chunks needed
+            from datetime import timedelta
+            total_days = (max_time - min_time).days + 1
+            max_days_per_chunk = 99
+            num_chunks = (total_days + max_days_per_chunk - 1) // max_days_per_chunk
+            
+            self.info(f"Splitting UNLOAD into {num_chunks} chunk(s)")
+            
+            chunk_start = min_time
+            chunk_num = 0
+            
+            while chunk_start <= max_time:
+                chunk_num += 1
+                chunk_end = min(chunk_start + timedelta(days=max_days_per_chunk - 1), max_time)
+                
+                start_str = chunk_start.strftime("%Y-%m-%d 00:00:00")
+                end_str = (chunk_end + timedelta(days=1)).strftime("%Y-%m-%d 00:00:00")
+                
+                self.info(f"UNLOAD chunk {chunk_num}/{num_chunks}: {chunk_start.date()} to {chunk_end.date()}")
+                
+                self.unload_table_chunk(table_name, start_str, end_str, chunk_num)
+                
+                chunk_start = chunk_end + timedelta(days=1)
+            
+            self.info(f"UNLOAD complete for table {table_name}: {chunk_num} chunk(s) processed")
+            
+        except Exception as e:
+            self.error(f"UNLOAD operation failed for s3://{self.s3_bucket_name}/{self.liveanalytics_database}/{table_name}/")
+            self.error(f"Error: {str(e)}")
+            
+            raise RuntimeError(
+                f"UNLOAD failed for table {table_name}: {str(e)}. "
+                f"Partial writes may exist in S3. Migration cancelled."
+            )
+
+    def get_table_time_range(self, table_name: str) -> tuple | None:
+        """
+        Gets the min and max time values from a Timestream table.
+
+        Args:
+            table_name (str): Name of the table.
+
+        Returns:
+            tuple: (min_datetime, max_datetime) or None if no data.
+        """
+        try:
+            response = self.timestream_query_client.query(
                 QueryString=f"""
-                    UNLOAD (SELECT *, DATE_FORMAT(time, '%y-%m-%d') as partition_date 
-                           FROM \"{self.liveanalytics_database}\".\"{table_name}\") 
-                    TO 's3://{self.s3_bucket_name}/{self.liveanalytics_database}/{table_name}' 
+                    SELECT min(time) as min_time, max(time) as max_time 
+                    FROM "{self.liveanalytics_database}"."{table_name}"
+                """
+            )
+            
+            rows = response.get("Rows", [])
+            if not rows:
+                return None
+            
+            row_data = rows[0].get("Data", [])
+            if len(row_data) < 2:
+                return None
+            
+            min_time_str = row_data[0].get("ScalarValue")
+            max_time_str = row_data[1].get("ScalarValue")
+            
+            if not min_time_str or not max_time_str:
+                return None
+            
+            from datetime import datetime
+            min_time = datetime.fromisoformat(min_time_str.replace(" ", "T").split(".")[0])
+            max_time = datetime.fromisoformat(max_time_str.replace(" ", "T").split(".")[0])
+            
+            return (min_time, max_time)
+            
+        except Exception as e:
+            self.warning(f"Failed to get time range for table {table_name}: {e}")
+            return None
+
+    def unload_table_chunk(self, table_name: str, start_time: str, end_time: str, chunk_num: int) -> None:
+        """
+        Unloads a time-bounded chunk of a table to S3 with partition_by day.
+        Each chunk writes to a unique path to get its own manifest file.
+
+        Args:
+            table_name (str): Name of the table.
+            start_time (str): Start time (inclusive) in format 'YYYY-MM-DD HH:MM:SS'.
+            end_time (str): End time (exclusive) in format 'YYYY-MM-DD HH:MM:SS'.
+            chunk_num (int): Chunk number for unique S3 path.
+        """
+        try:
+            chunk_path = f"s3://{self.s3_bucket_name}/{self.liveanalytics_database}/{table_name}/chunk_{chunk_num:03d}"
+            
+            # Use partition_by for smaller files (one per day)
+            response = self.timestream_query_client.query(
+                QueryString=f"""
+                    UNLOAD (
+                        SELECT *, DATE_FORMAT(time, '%y-%m-%d') as partition_date 
+                        FROM "{self.liveanalytics_database}"."{table_name}"
+                        WHERE time >= '{start_time}' AND time < '{end_time}'
+                    ) 
+                    TO '{chunk_path}' 
                     WITH (partitioned_by = ARRAY['partition_date'], 
                           format = 'PARQUET', 
                           max_file_size='16MB', 
                           compression = 'NONE')
                 """
             )
+            
+            http_status = response.get("ResponseMetadata", {}).get("HTTPStatusCode", 0)
+            if http_status < 200 or http_status >= 300:
+                raise RuntimeError(f"UNLOAD chunk returned HTTP {http_status}")
+            
+            self.info(f"UNLOAD chunk completed")
+            
+            # Wait for manifest file and store info
+            manifest_info = self.wait_for_manifest_file(table_name, chunk_num)
+            if manifest_info:
+                if not hasattr(self, 'table_manifests'):
+                    self.table_manifests = {}
+                if table_name not in self.table_manifests:
+                    self.table_manifests[table_name] = []
+                self.table_manifests[table_name].append(manifest_info)
+                self.info(
+                    f"Chunk {chunk_num} manifest: {manifest_info['file_count']} files, "
+                    f"{manifest_info['total_rows']:,} rows"
+                )
+            else:
+                raise RuntimeError(f"Manifest file not found for chunk {chunk_num}")
+            
+        except ClientError as e:
+            error_code = e.response.get("Error", {}).get("Code", "")
+            raise RuntimeError(f"UNLOAD chunk failed: {error_code} - {str(e)}")
 
-            self.info(f"Successfully initiated unload for table: {table_name}")
-        except (ClientError, BotoCoreError) as e:
-            self.error("UNLOAD operation failed: ", str(e))
-
-    def get_s3_objects_list(
-        self, wait_period_seconds=20, max_wait_seconds=1_800
-    ) -> list[str]:
+    def wait_for_manifest_file(
+        self,
+        table_name: str,
+        chunk_num: int,
+        poll_interval_seconds: int = 5,
+        max_wait_seconds: int = 300
+    ) -> dict | None:
         """
-        Gets a list of parquet files in an S3 bucket.
+        Waits for the Timestream UNLOAD manifest file to appear in S3.
+        The manifest file contains the complete list of parquet files and row counts.
+
+        Args:
+            table_name (str): Name of the table being unloaded.
+            chunk_num (int): Chunk number to find specific manifest.
+            poll_interval_seconds (int): Seconds between S3 checks. Default 5.
+            max_wait_seconds (int): Maximum seconds to wait. Default 300 (5 minutes).
 
         Returns:
-            list[str]: List of parquet file keys
+            dict: Manifest info with 'file_count', 'total_rows', 'files' or None if not found.
         """
-
-        parquet_keys: set[str] = set()
-        processed_keys: set[str] = set()
-        files_to_migrate: set[str] = set()
-
-        total_wait_seconds = 0
-        while total_wait_seconds < max_wait_seconds:
+        manifest_prefix = f"{self.liveanalytics_database}/{table_name}/chunk_{chunk_num:03d}/"
+        elapsed_seconds = 0
+        
+        self.info(f"Waiting for manifest file for table {table_name}...")
+        
+        while elapsed_seconds < max_wait_seconds:
             try:
-                # Use paginator to handle large buckets.
                 paginator = self.s3_client.get_paginator("list_objects_v2")
-                page_iterator = paginator.paginate(
-                    Bucket=self.s3_bucket_name, Prefix=self.liveanalytics_database
-                )
-
-                for page in page_iterator:
+                
+                for page in paginator.paginate(Bucket=self.s3_bucket_name, Prefix=manifest_prefix):
                     for obj in page.get("Contents", []):
-                        key = obj.get("Key")
-                        if not key:
-                            continue
-                        if key.endswith(".parquet"):
-                            self.info(f"Parquet file size: {obj.get('Size')} bytes")
-                            parquet_keys.add(key)
-                        if key.endswith("done.ack"):
-                            processed_keys.add(key.strip("/done.ack"))
-                files_to_migrate = parquet_keys - processed_keys
-
-            except ClientError as e:
-                error_code: str = e.response.get("Error", {}).get("Code", "")
-                if error_code == "NoSuchBucket":
-                    self.info(
-                        "Error: Bucket " + self.s3_bucket_name + " does not exist."
-                    )
-                elif error_code == "AccessDenied":
-                    self.info(
-                        "Error: Access denied to bucket "
-                        + self.s3_bucket_name
-                        + ". Check your AWS credentials and permissions."
-                    )
-                else:
-                    self.info(
-                        "Error listing objects in bucket "
-                        + self.s3_bucket_name
-                        + ": "
-                        + str(e)
-                    )
-                return []
+                        key = obj.get("Key", "")
+                        if "_manifest" in key:
+                            self.info(f"Found manifest file: {key}")
+                            return self.parse_manifest_file(key)
+                
+                self.info(f"Waiting for manifest file... ({elapsed_seconds}s elapsed)")
+                
             except Exception as e:
-                self.info("Unexpected error while listing objects: " + str(e))
-                return []
+                self.warning(f"Error checking for manifest file: {e}")
+            
+            time.sleep(poll_interval_seconds)
+            elapsed_seconds += poll_interval_seconds
+        
+        self.warning(
+            f"Manifest file not found for table {table_name} after {max_wait_seconds}s"
+        )
+        return None
 
-            if len(files_to_migrate) == 0:
-                if total_wait_seconds + wait_period_seconds >= max_wait_seconds:
-                    raise RuntimeError(
-                        f"No Parquet files found in {self.s3_bucket_name}"
-                    )
-                self.warning(
-                    f"No parquet files found in bucket {self.s3_bucket_name}. Retrying"
-                )
-                total_wait_seconds += wait_period_seconds
-                time.sleep(wait_period_seconds)
-            else:
-                break
+    def parse_manifest_file(self, manifest_key: str) -> dict | None:
+        """
+        Parses the Timestream UNLOAD manifest file to get file list and row counts.
+        
+        Manifest format:
+        {
+          "result_files": [
+            {"url": "s3://...", "file_metadata": {"row_count": 10}},
+            ...
+          ],
+          "query_metadata": {"total_row_count": 30},
+          "author": {"name": "Amazon Timestream", "manifest_file_version": "1.0"}
+        }
 
-        self.info(f"Found {len(files_to_migrate)} parquet files")
-        return list(files_to_migrate)
+        Args:
+            manifest_key (str): S3 key of the manifest file.
+
+        Returns:
+            dict: Contains 'file_count', 'total_rows', 'files' list.
+        """
+        try:
+            response = self.s3_client.get_object(
+                Bucket=self.s3_bucket_name, Key=manifest_key
+            )
+            manifest_content = response["Body"].read().decode("utf-8")
+            manifest = json.loads(manifest_content)
+            
+            result_files = manifest.get("result_files", [])
+            query_metadata = manifest.get("query_metadata", {})
+            total_rows = query_metadata.get("total_row_count", 0)
+            
+            if total_rows == 0:
+                raise RuntimeError(f"Failed to get row count for manifest {manifest_key}")
+            
+            return {
+                "file_count": len(result_files),
+                "total_rows": total_rows,
+                "files": result_files,
+            }
+            
+        except Exception as e:
+            self.warning(f"Failed to parse manifest file {manifest_key}: {e}")
+            return None
+
+    def get_parquet_files_from_manifests(self) -> list[str]:
+        """
+        Gets the list of parquet files from manifest files generated during UNLOAD.
+
+        Returns:
+            list[str]: List of parquet file S3 keys
+
+        Raises:
+            RuntimeError: If no manifest files are available.
+        """
+        if not hasattr(self, 'table_manifests') or not self.table_manifests:
+            raise RuntimeError(
+                "No manifest files found. UNLOAD must complete successfully "
+                "and generate manifest files before migration can proceed."
+            )
+        
+        parquet_keys: list[str] = []
+        total_rows = 0
+        
+        for table_name, manifest_list in self.table_manifests.items():
+            table_files = 0
+            table_rows = 0
+            
+            for manifest_info in manifest_list:
+                files = manifest_info.get("files", [])
+                table_files += len(files)
+                table_rows += manifest_info.get("total_rows", 0)
+                
+                for file_entry in files:
+                    url = file_entry.get("url", "")
+                    if url:
+                        parts = url.replace("s3://", "").split("/", 1)
+                        if len(parts) == 2:
+                            s3_key = parts[1]
+                            parquet_keys.append(s3_key)
+            
+            self.info(f"Table {table_name}: {table_files} files, {table_rows:,} rows from {len(manifest_list)} chunks")
+            total_rows += table_rows
+        
+        if not parquet_keys:
+            raise RuntimeError(
+                "No parquet files found in manifest files. "
+                "UNLOAD may have produced empty results."
+            )
+        
+        self.info(f"Total: {len(parquet_keys)} parquet files, {total_rows:,} rows")
+        return parquet_keys
 
     def generate_metadata(
         self, parquet_file_names: list[str], expiration: int = 604_800
     ) -> dict[str, dict[str, str]]:
         """
-        Generates metadata, including pre-signed URLs for S3 objects.
+        Generates metadata, including presigned URLs for S3 objects.
         This metadata will be a dict[str, dict[str, str]] with the following structure:
 
             {
@@ -263,25 +458,20 @@ class InfluxDBMigrationWrapper:
                 and PUT URLs.
         """
 
-        # Metadata is eventually ingested into InfluxDB v3 and is used by the plugin
-        # to manage states and access S3 using pre-signed (GET and PUT) URLs.
         metadata = {}
 
         for file_key in parquet_file_names:
             try:
-                # Place legal hold object lock on Parquet file.
                 _ = self.s3_client.put_object_legal_hold(
                     Bucket=self.s3_bucket_name, Key=file_key, LegalHold={"Status": "ON"}
                 )
 
-                # Generate pre-signed URLs.
                 presigned_get_url: str = self.s3_client.generate_presigned_url(
                     "get_object",
                     Params={"Bucket": self.s3_bucket_name, "Key": file_key},
                     ExpiresIn=expiration,
                 )
                 # "Done" files (done.ack) will not have an object lock. Object locks for
-                # pre-signed put_object calls are not supported.
                 presigned_done_url: str = self.s3_client.generate_presigned_url(
                     "put_object",
                     Params={
@@ -405,28 +595,101 @@ class InfluxDBMigrationWrapper:
             self.error(f"Failed to write metadata to InfluxDB: ", str(e))
             sys.exit(1)
 
+    def get_s3_objects_list(
+        self, wait_period_seconds=20, max_wait_seconds=1_800
+    ) -> list[str]:
+        """
+        Gets a list of parquet files in an S3 bucket by scanning S3.
+
+        Returns:
+            list[str]: List of parquet file keys
+        """
+
+        parquet_keys: set[str] = set()
+        processed_keys: set[str] = set()
+        files_to_migrate: set[str] = set()
+
+        total_wait_seconds = 0
+        while total_wait_seconds < max_wait_seconds:
+            try:
+                # Use paginator to handle large buckets.
+                paginator = self.s3_client.get_paginator("list_objects_v2")
+                page_iterator = paginator.paginate(
+                    Bucket=self.s3_bucket_name, Prefix=self.liveanalytics_database
+                )
+
+                for page in page_iterator:
+                    for obj in page.get("Contents", []):
+                        key = obj.get("Key")
+                        if not key:
+                            continue
+                        if key.endswith(".parquet"):
+                            parquet_keys.add(key)
+                        if key.endswith("done.ack"):
+                            processed_keys.add(key.replace("/done.ack", ""))
+                files_to_migrate = parquet_keys - processed_keys
+
+            except ClientError as e:
+                error_code: str = e.response.get("Error", {}).get("Code", "")
+                if error_code == "NoSuchBucket":
+                    self.error(f"Error: Bucket {self.s3_bucket_name} does not exist.")
+                elif error_code == "AccessDenied":
+                    self.error(f"Error: Access denied to bucket {self.s3_bucket_name}.")
+                else:
+                    self.error(f"Error listing objects in bucket {self.s3_bucket_name}: {str(e)}")
+                return []
+            except Exception as e:
+                self.error(f"Unexpected error while listing objects: {str(e)}")
+                return []
+
+            if len(files_to_migrate) == 0:
+                if total_wait_seconds + wait_period_seconds >= max_wait_seconds:
+                    raise RuntimeError(f"No Parquet files found in {self.s3_bucket_name}")
+                self.warning(f"No parquet files found in bucket {self.s3_bucket_name}. Retrying")
+                total_wait_seconds += wait_period_seconds
+                time.sleep(wait_period_seconds)
+            else:
+                break
+
+        self.info(f"Found {len(files_to_migrate)} parquet files to migrate")
+        return list(files_to_migrate)
+
     def bulk_invoke_http_trigger(self, metadata):
         """
         Invokes the HTTP migration processing engine trigger for all Parquet files to be migrated.
 
         Args:
-            metadata (dict[str, dict[str, str]]): Mapping of random UUIDs to a file's
-                pre-signed (GET and DELETE) URLs and migration status.
+            metadata (dict[str, dict[str, str]]): Mapping of S3 keys to presigned URLs.
 
         Returns:
             None
         """
+        session = requests.Session()
+        
+        adapter = requests.adapters.HTTPAdapter(
+            pool_connections=10,
+            pool_maxsize=10,
+            max_retries=requests.adapters.Retry(
+                total=3,
+                backoff_factor=1,
+                status_forcelist=[500, 502, 503, 504],
+                allowed_methods=["POST"],
+            ),
+        )
+        session.mount("https://", adapter)
+        session.headers.update({"Connection": "keep-alive"})
+        
         try:
             metadata_table_deleted: bool = False
             url = f"{self.influx_host}/api/v3/engine/{TRIGGER_NAME}"
             headers = {"Authorization": f"Bearer {self.influx_token}"}
+            
             for s3_key in metadata:
                 table_name = s3_key.split("/")[1]
-                self.info(
-                    f'Migrating {s3_key} to "{self.influx_database}"."{table_name}"'
-                )
+                self.info(f'Migrating {s3_key} to "{self.influx_database}"."{table_name}"')
                 json_body = {"parquet_path": s3_key}
-                trigger_invocation_response = requests.post(
+                
+                trigger_invocation_response = session.post(
                     url=url,
                     json=json_body,
                     headers=headers,
@@ -434,33 +697,36 @@ class InfluxDBMigrationWrapper:
                 )
                 trigger_invocation_response.raise_for_status()
                 response_body = trigger_invocation_response.json()
+                
                 if response_body["status"] != 200 and response_body["status"] != 202:
-                    raise RuntimeError(
-                        f"Migrating {s3_key} failed: {response_body['message']}"
-                    )
+                    raise RuntimeError(f"Migrating {s3_key} failed: {response_body['message']}")
+                    
                 if not metadata_table_deleted:
                     self.delete_metadata_table()
                     metadata_table_deleted = True
 
             # Final verification invocation.
             verification_params = {"verify": True, "delete_cache": True}
-            final_invocation_response = requests.post(
+            final_invocation_response = session.post(
                 url=url,
                 headers=headers,
                 params=verification_params,
                 timeout=self.timeout_seconds,
             )
             final_invocation_response.raise_for_status()
-            if final_invocation_response.json()["status"] != 200:
-                raise Exception(
-                    f"Final verification failed: {final_invocation_response.json()['message']}"
-                )
+            response_json = final_invocation_response.json()
+            
+            if response_json["status"] != 200:
+                raise Exception(f"Final verification failed: {response_json['message']}")
+            
+            # Store expected table row counts for final verification
+            self.expected_table_row_counts = response_json.get("table_row_counts", {})
+            
         except Exception as e:
-            self.error(
-                f"HTTP invocation failed: {e}. View processing engine logs for more information"
-            )
+            self.error(f"HTTP invocation failed: {e}. View processing engine logs for more information")
             raise
         finally:
+            session.close()
             self.delete_trigger()
 
     def get_num_completed_and_total_parquet_files(self):
@@ -498,7 +764,7 @@ class InfluxDBMigrationWrapper:
             trigger_payload = {
                 "db": self.influx_database,
                 "trigger_name": TRIGGER_NAME,
-                "plugin_filename": "liveanalytics_migration_plugin/liveanalytics_migration_plugin.py",
+                "plugin_filename": "gh:liveanalytics_migration_plugin/liveanalytics_migration_plugin.py",
                 "trigger_specification": f"request:{TRIGGER_NAME}",  # Creates /api/v3/engine/<TRIGGER_NAME> endpoint.
                 "trigger_settings": {"run_async": False, "error_behavior": "log"},
                 "disabled": "true",
@@ -639,7 +905,8 @@ class InfluxDBMigrationWrapper:
         else:
             self.info("Resuming migration and skipping unload operations")
 
-        parquet_file_names: list[str] = self.get_s3_objects_list()
+        # Get parquet file list from manifest files (generated during each UNLOAD chunk)
+        parquet_file_names: list[str] = self.get_parquet_files_from_manifests()
 
         metadata: dict[str, dict[str, str]] = self.generate_metadata(
             parquet_file_names=parquet_file_names
@@ -653,6 +920,10 @@ class InfluxDBMigrationWrapper:
         self.write_metadata_to_influxdb(metadata)
         self.create_processing_engine_trigger()
         self.bulk_invoke_http_trigger(metadata)
+        
+        # Final verification: compare expected row counts from plugin with actual InfluxDB counts
+        self.verify_final_row_counts()
+        
         self.delete_unloaded_data()
 
         self.info("Migration wrapper completed successfully")
@@ -718,6 +989,77 @@ class InfluxDBMigrationWrapper:
                     )
 
         return
+
+    def verify_final_row_counts(self) -> bool:
+        """
+        Verifies that all tables in the migrated database have the correct row counts
+        by comparing the expected counts from plugin with actual InfluxDB counts.
+        We verify counts returned from plugin as records that contain NaN or Null
+        only values for measures will be ignored and skew the final count.
+        
+        Returns:
+            bool: True if all tables match, False if any mismatch is found.
+        """
+        if not hasattr(self, 'expected_table_row_counts') or not self.expected_table_row_counts:
+            self.warning("No expected table row counts available for verification")
+            return True
+        
+        self.info("Final verification to compare row counts")
+        
+        all_verified = True
+        verification_results = []
+        
+        for table_name, expected_count in self.expected_table_row_counts.items():
+            actual_count = None
+            try:
+                query_str = f'SELECT COUNT(*) AS row_count FROM "{table_name}"'
+                result = self.influxdb_client.query(query_str)
+                if result and len(result) > 0:
+                    actual_count = result.column("row_count")[0].as_py()
+            except Exception as e:
+                self.error(f"Failed to query InfluxDB table {table_name}: {e}")
+                actual_count = None
+            
+            if actual_count is None:
+                status = "ERROR"
+                all_verified = False
+            elif actual_count == expected_count:
+                status = "MATCH"
+            else:
+                status = "MISMATCH"
+                all_verified = False
+            
+            verification_results.append({
+                "table": table_name,
+                "expected_count": expected_count,
+                "actual_count": actual_count,
+                "status": status,
+            })
+        
+        self.info("")
+        self.info(f"{'Table':<40} {'Expected':>15} {'Actual':>15} {'Status':>10}")
+        
+        for result in verification_results:
+            expected = f"{result['expected_count']:,}"
+            actual = f"{result['actual_count']:,}" if result['actual_count'] is not None else "ERROR"
+            self.info(f"{result['table']:<40} {expected:>15} {actual:>15} {result['status']:>10}")
+        
+        
+        if all_verified:
+            self.info("All tables verified successfully")
+        else:
+            self.warning("Some tables have mismatched row counts during migration")
+            for result in verification_results:
+                if result["status"] == "MISMATCH":
+                    diff = (result['actual_count'] or 0) - (result['expected_count'] or 0)
+                    self.warning(
+                        f"  Table '{result['table']}': "
+                        f"Expected={result['expected_count']}, "
+                        f"Actual={result['actual_count']}, "
+                        f"Difference={diff:+d}"
+                    )
+        
+        return all_verified
 
     def verify_bucket(self):
         """
@@ -914,3 +1256,4 @@ Examples:
 
 if __name__ == "__main__":
     main(sys.argv[1:])
+

--- a/tools/python/liveanalytics_influxdb3_migration_plugin/liveanalytics_migration_client/liveanalytics_influxdb3_migration_client.py
+++ b/tools/python/liveanalytics_influxdb3_migration_plugin/liveanalytics_migration_client/liveanalytics_influxdb3_migration_client.py
@@ -24,6 +24,7 @@ from datetime import datetime, timezone
 
 MIGRATION_METADATA_TABLE: str = "liveanalytics_migration_metadata"
 TRIGGER_NAME: str = "migration_trigger"
+UNLOAD_WAIT_SECONDS: int = 20
 
 
 class InfluxDBMigrationWrapper:
@@ -150,7 +151,7 @@ class InfluxDBMigrationWrapper:
         self.info(f"Unloading table: {table_name}")
 
         try:
-            _ = self.timestream_query_client.query(
+            unload_result = self.timestream_query_client.query(
                 QueryString=f"""
                     UNLOAD (SELECT *, DATE_FORMAT(time, '%y-%m-%d') as partition_date 
                            FROM \"{self.liveanalytics_database}\".\"{table_name}\") 
@@ -159,10 +160,32 @@ class InfluxDBMigrationWrapper:
                           format = 'PARQUET', 
                           max_file_size='16MB', 
                           compression = 'NONE')
-                """
+                    """
             )
 
             self.info(f"Successfully initiated unload for table: {table_name}")
+            next_token = unload_result.get("NextToken")
+            while next_token is not None:
+                unload_result = self.timestream_query_client.query(
+                    NextToken=next_token,
+                    QueryString=f"""
+                    UNLOAD (SELECT *, DATE_FORMAT(time, '%y-%m-%d') as partition_date 
+                           FROM \"{self.liveanalytics_database}\".\"{table_name}\") 
+                    TO 's3://{self.s3_bucket_name}/{self.liveanalytics_database}/{table_name}' 
+                    WITH (partitioned_by = ARRAY['partition_date'], 
+                          format = 'PARQUET', 
+                          max_file_size='16MB', 
+                          compression = 'NONE')
+                    """,
+                )
+                next_token = unload_result.get("NextToken")
+                unload_progress = unload_result.get("QueryStatus", {}).get(
+                    "ProgressPercentage"
+                )
+                self.info(f"Unload progress: {unload_progress}%")
+                if unload_progress >= 100.0:
+                    break
+                time.sleep(UNLOAD_WAIT_SECONDS)
         except (ClientError, BotoCoreError) as e:
             self.error("UNLOAD operation failed: ", str(e))
 

--- a/tools/python/liveanalytics_influxdb3_migration_plugin/liveanalytics_migration_client/liveanalytics_influxdb3_migration_client.py
+++ b/tools/python/liveanalytics_influxdb3_migration_plugin/liveanalytics_migration_client/liveanalytics_influxdb3_migration_client.py
@@ -504,6 +504,81 @@ class InfluxDBMigrationWrapper:
         self.info(f"Total: {len(parquet_keys)} parquet files, {total_rows:,} rows")
         return parquet_keys
 
+    def get_s3_objects_list(
+        self, wait_period_seconds=20, max_wait_seconds=1_800
+    ) -> list[str]:
+        """
+        Gets a list of parquet files in an S3 bucket.
+
+        Returns:
+            list[str]: List of parquet file keys
+        """
+
+        parquet_keys: set[str] = set()
+        processed_keys: set[str] = set()
+        files_to_migrate: set[str] = set()
+
+        total_wait_seconds = 0
+        while total_wait_seconds < max_wait_seconds:
+            try:
+                # Use paginator to handle large buckets.
+                paginator = self.s3_client.get_paginator("list_objects_v2")
+                page_iterator = paginator.paginate(
+                    Bucket=self.s3_bucket_name, Prefix=self.liveanalytics_database
+                )
+
+                for page in page_iterator:
+                    for obj in page.get("Contents", []):
+                        key = obj.get("Key")
+                        if not key:
+                            continue
+                        if key.endswith(".parquet"):
+                            self.debug(f"Parquet file size: {obj.get('Size')} bytes")
+                            parquet_keys.add(key)
+                        if key.endswith("done.ack"):
+                            processed_keys.add(key.strip("/done.ack"))
+                files_to_migrate = parquet_keys - processed_keys
+
+            except ClientError as e:
+                error_code: str = e.response.get("Error", {}).get("Code", "")
+                if error_code == "NoSuchBucket":
+                    self.info(
+                        "Error: Bucket " + self.s3_bucket_name + " does not exist."
+                    )
+                elif error_code == "AccessDenied":
+                    self.info(
+                        "Error: Access denied to bucket "
+                        + self.s3_bucket_name
+                        + ". Check your AWS credentials and permissions."
+                    )
+                else:
+                    self.info(
+                        "Error listing objects in bucket "
+                        + self.s3_bucket_name
+                        + ": "
+                        + str(e)
+                    )
+                return []
+            except Exception as e:
+                self.info("Unexpected error while listing objects: " + str(e))
+                return []
+
+            if len(files_to_migrate) == 0:
+                if total_wait_seconds + wait_period_seconds >= max_wait_seconds:
+                    raise RuntimeError(
+                        f"No Parquet files found in {self.s3_bucket_name}"
+                    )
+                self.warning(
+                    f"No parquet files found in bucket {self.s3_bucket_name}. Retrying"
+                )
+                total_wait_seconds += wait_period_seconds
+                time.sleep(wait_period_seconds)
+            else:
+                break
+
+        self.info(f"Found {len(files_to_migrate)} parquet files")
+        return list(files_to_migrate)
+
     def generate_metadata(
         self, parquet_file_names: list[str], expiration: int = 604_800
     ) -> dict[str, dict[str, str]]:
@@ -758,6 +833,14 @@ class InfluxDBMigrationWrapper:
             response_json = final_invocation_response.json()
 
             if response_json["status"] != 200:
+                if self.max_parquet_files is not None and self.max_parquet_files < len(
+                    metadata
+                ):
+                    num_remaining_files = len(metadata) - self.max_parquet_files
+                    self.warning(
+                        f"{self.max_parquet_files} files have been migrated, {num_remaining_files} remain. Final verification failed: {response_json['message']}"
+                    )
+                    return
                 raise Exception(
                     f"Final verification failed: {response_json['message']}"
                 )
@@ -953,7 +1036,7 @@ class InfluxDBMigrationWrapper:
         self.unload_db(self.resume_migration)
 
         # Get parquet file list from manifest files (generated during each UNLOAD chunk)
-        parquet_file_names: list[str] = self.get_parquet_files_from_manifests()
+        parquet_file_names: list[str] = self.get_s3_objects_list()
 
         metadata: dict[str, dict[str, str]] = self.generate_metadata(
             parquet_file_names=parquet_file_names
@@ -967,6 +1050,11 @@ class InfluxDBMigrationWrapper:
         self.write_metadata_to_influxdb(metadata)
         self.create_processing_engine_trigger()
         self.bulk_invoke_http_trigger(metadata)
+        if self.max_parquet_files is not None and self.max_parquet_files < len(
+            metadata
+        ):
+            self.warning("Migration partially completed")
+            return
 
         # Final verification: compare expected row counts from plugin with actual InfluxDB counts
         self.verify_final_row_counts()

--- a/tools/python/liveanalytics_influxdb3_migration_plugin/liveanalytics_migration_client/liveanalytics_influxdb3_migration_client.py
+++ b/tools/python/liveanalytics_influxdb3_migration_plugin/liveanalytics_migration_client/liveanalytics_influxdb3_migration_client.py
@@ -34,6 +34,7 @@ class InfluxDBMigrationWrapper:
         resume_migration: bool = False,
         timeout_seconds: int = 120,
         region: str = "us-west-2",
+        max_parquet_files: int | None = None,
     ) -> None:
         """
         Initialize
@@ -44,6 +45,7 @@ class InfluxDBMigrationWrapper:
             resume_migration (bool): Whether to resume an existing migration, skipping unload operations.
             timeout_seconds (int): The number of seconds to wait for each migration request.
             region (str): The AWS Region to use.
+            max_parquet_files (int | None): The maximum number of Parquet files to migrate.
 
         Returns:
             None
@@ -53,6 +55,7 @@ class InfluxDBMigrationWrapper:
         self.resume_migration: bool = resume_migration
         self.timeout_seconds: int = timeout_seconds
         self.region: str = region
+        self.max_parquet_files: int | None = max_parquet_files
 
         logging.basicConfig(
             level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s"
@@ -105,7 +108,9 @@ class InfluxDBMigrationWrapper:
         Returns:
             None
         """
-        self.info(f"Starting unload operation for database: {self.liveanalytics_database}")
+        self.info(
+            f"Starting unload operation for database: {self.liveanalytics_database}"
+        )
 
         tables = []
         next_token = None
@@ -420,7 +425,13 @@ class InfluxDBMigrationWrapper:
             metadata_table_deleted: bool = False
             url = f"{self.influx_host}/api/v3/engine/{TRIGGER_NAME}"
             headers = {"Authorization": f"Bearer {self.influx_token}"}
+            num_parquet_files_submitted = 0
             for s3_key in metadata:
+                if (
+                    self.max_parquet_files is not None
+                    and num_parquet_files_submitted >= self.max_parquet_files
+                ):
+                    break
                 table_name = s3_key.split("/")[1]
                 self.info(
                     f'Migrating {s3_key} to "{self.influx_database}"."{table_name}"'
@@ -441,6 +452,7 @@ class InfluxDBMigrationWrapper:
                 if not metadata_table_deleted:
                     self.delete_metadata_table()
                     metadata_table_deleted = True
+                num_parquet_files_submitted += 1
 
             # Final verification invocation.
             verification_params = {"verify": True, "delete_cache": True}
@@ -460,8 +472,9 @@ class InfluxDBMigrationWrapper:
                 f"HTTP invocation failed: {e}. View processing engine logs for more information"
             )
             raise
-        finally:
-            self.delete_trigger()
+        # Trigger is only deleted when a migration is successful. This allows users to resume a
+        # migration if an error occurs.
+        self.delete_trigger()
 
     def get_num_completed_and_total_parquet_files(self):
         """
@@ -475,7 +488,9 @@ class InfluxDBMigrationWrapper:
         bucket = s3.Bucket(self.s3_bucket_name)
         parquet_count: int = 0
         completed_count: int = 0
-        for obj in bucket.objects.filter(Prefix=f"{self.liveanalytics_database}/").all():
+        for obj in bucket.objects.filter(
+            Prefix=f"{self.liveanalytics_database}/"
+        ).all():
             if obj.key.endswith(".parquet"):
                 parquet_count += 1
             if obj.key.endswith(".ack"):
@@ -518,10 +533,7 @@ class InfluxDBMigrationWrapper:
                 f"{self.influx_host}/api/v3/configure/processing_engine_trigger"
             )
 
-            delete_body = {
-                "db": self.influx_database,
-                "trigger_name": TRIGGER_NAME
-            }
+            delete_body = {"db": self.influx_database, "trigger_name": TRIGGER_NAME}
 
             delete_response = requests.delete(
                 delete_trigger_url, json=delete_body, headers=headers
@@ -873,6 +885,12 @@ Examples:
         default="us-west-2",
         help="Optional. The AWS Region to use. Defaults to us-west-2.",
     )
+    parser.add_argument(
+        "--max-parquet-files",
+        required=False,
+        type=int,
+        help="Optional. The maximum number of Parquet files to migrate. Default behaviour is to migrate all Parquet files.",
+    )
 
     args = parser.parse_args(input_args)
 
@@ -881,6 +899,7 @@ Examples:
     resume_migration: bool = args.resume
     timeout_seconds: int = args.timeout_seconds
     region: str = args.region
+    max_parquet_files: int | None = args.max_parquet_files
 
     required_env_vars = [
         "INFLUXDB3_HOST_URL",
@@ -902,6 +921,7 @@ Examples:
         resume_migration=resume_migration,
         timeout_seconds=timeout_seconds,
         region=region,
+        max_parquet_files=max_parquet_files,
     )
 
     try:

--- a/tools/python/liveanalytics_influxdb3_migration_plugin/liveanalytics_migration_client/liveanalytics_influxdb3_migration_client.py
+++ b/tools/python/liveanalytics_influxdb3_migration_plugin/liveanalytics_migration_client/liveanalytics_influxdb3_migration_client.py
@@ -764,7 +764,7 @@ class InfluxDBMigrationWrapper:
             trigger_payload = {
                 "db": self.influx_database,
                 "trigger_name": TRIGGER_NAME,
-                "plugin_filename": "gh:liveanalytics_migration_plugin/liveanalytics_migration_plugin.py",
+                "plugin_filename": "liveanalytics_migration_plugin/liveanalytics_migration_plugin.py",
                 "trigger_specification": f"request:{TRIGGER_NAME}",  # Creates /api/v3/engine/<TRIGGER_NAME> endpoint.
                 "trigger_settings": {"run_async": False, "error_behavior": "log"},
                 "disabled": "true",

--- a/tools/python/liveanalytics_influxdb3_migration_plugin/liveanalytics_migration_client/tests/integration/test_liveanalytics_influxdb3_migration_client.py
+++ b/tools/python/liveanalytics_influxdb3_migration_plugin/liveanalytics_migration_client/tests/integration/test_liveanalytics_influxdb3_migration_client.py
@@ -668,64 +668,19 @@ class MigrationTestCase(unittest.TestCase):
 
         print("Generating data")
         records = []
+        dimensions = [
+            {
+                "Name": "hostname",
+                "Value": self.get_random_string(12),
+                "DimensionValueType": "VARCHAR",
+            },
+            {
+                "Name": "region",
+                "Value": self.get_random_string(18),
+                "DimensionValueType": "VARCHAR",
+            },
+        ]
         for _ in range(200):
-            dimensions = [
-                {
-                    "Name": "hostname",
-                    "Value": self.get_random_string(12),
-                    "DimensionValueType": "VARCHAR",
-                },
-                {
-                    "Name": "region",
-                    "Value": self.get_random_string(18),
-                    "DimensionValueType": "VARCHAR",
-                },
-                {
-                    "Name": "statat",
-                    "Value": self.get_random_string(2),
-                    "DimensionValueType": "VARCHAR",
-                },
-                {
-                    "Name": "mono",
-                    "Value": self.get_random_string(25),
-                    "DimensionValueType": "VARCHAR",
-                },
-                {
-                    "Name": "som",
-                    "Value": self.get_random_string(10),
-                    "DimensionValueType": "VARCHAR",
-                },
-                {
-                    "Name": "cher",
-                    "Value": self.get_random_string(4),
-                    "DimensionValueType": "VARCHAR",
-                },
-                {
-                    "Name": "no",
-                    "Value": self.get_random_string(15),
-                    "DimensionValueType": "VARCHAR",
-                },
-                {
-                    "Name": "sine",
-                    "Value": self.get_random_string(26),
-                    "DimensionValueType": "VARCHAR",
-                },
-                {
-                    "Name": "reno",
-                    "Value": self.get_random_string(11),
-                    "DimensionValueType": "VARCHAR",
-                },
-                {
-                    "Name": "sing",
-                    "Value": self.get_random_string(6),
-                    "DimensionValueType": "VARCHAR",
-                },
-                {
-                    "Name": "bus",
-                    "Value": self.get_random_string(18),
-                    "DimensionValueType": "VARCHAR",
-                },
-            ]
             record = {
                 "Dimensions": dimensions,
                 "MeasureName": "cpu_utilization",
@@ -749,8 +704,7 @@ class MigrationTestCase(unittest.TestCase):
                 "1",
             ]
         )
-        # Since not all files are migrated, final verification will fail.
-        self.assertEqual(return_code, 1)
+        self.assertEqual(return_code, 0)
 
         return_code = liveanalytics_influxdb3_migration_client.main(
             [
@@ -992,8 +946,7 @@ class MigrationTestCase(unittest.TestCase):
                 "1",
             ]
         )
-        # Since not all files are migrated, final verification will fail.
-        self.assertEqual(return_code, 1)
+        self.assertEqual(return_code, 0)
 
         return_code = liveanalytics_influxdb3_migration_client.main(
             [

--- a/tools/python/liveanalytics_influxdb3_migration_plugin/liveanalytics_migration_client/tests/integration/test_liveanalytics_influxdb3_migration_client.py
+++ b/tools/python/liveanalytics_influxdb3_migration_plugin/liveanalytics_migration_client/tests/integration/test_liveanalytics_influxdb3_migration_client.py
@@ -76,6 +76,7 @@ class MigrationTestCase(unittest.TestCase):
                 "/usr/lib/influxdb3/python/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
             )
             .with_env("LOG_FILTER", "info")
+            .with_kwargs(mem_limit="8g", memswap_limit="8g")
             .waiting_for(LogMessageWaitStrategy(re.compile(".*startup time.*")))
             .with_bind_ports(container="8181/tcp", host=8183)
             .start()

--- a/tools/python/liveanalytics_influxdb3_migration_plugin/liveanalytics_migration_client/tests/integration/test_liveanalytics_influxdb3_migration_client.py
+++ b/tools/python/liveanalytics_influxdb3_migration_plugin/liveanalytics_migration_client/tests/integration/test_liveanalytics_influxdb3_migration_client.py
@@ -66,7 +66,8 @@ class MigrationTestCase(unittest.TestCase):
                     "--node-id=my-node-0 "
                     "--object-store=file "
                     "--data-dir=/var/lib/influxdb3/data "
-                    "--plugin-dir=/var/lib/influxdb3/plugins"
+                    "--plugin-dir=/var/lib/influxdb3/plugins "
+                    "--query-file-limit=5000"
                 ),
                 volumes=[(str(plugin_dir), "/var/lib/influxdb3/plugins", "rw")],
             )
@@ -692,6 +693,90 @@ class MigrationTestCase(unittest.TestCase):
         )
 
         self.assertEqual(return_code, 0)
+        la_table_count = self.check_live_analytics_table_count(
+            database_name=self.la_database_name, table_name=self.la_table_name
+        )
+        influxdb_v3_table_count = self.check_influxdb_v3_table_count(
+            database_name=self.influx_database, table_name=self.la_table_name
+        )
+        print(f"Table counts: {la_table_count}, {influxdb_v3_table_count}")
+        self.assertEqual(
+            la_table_count,
+            influxdb_v3_table_count,
+        )
+
+    @pytest.mark.slow
+    def test_migration_massive_resume(self):
+        """
+        Tests migrating 2,000,000 records with --resume.
+
+        This tests assumes that migrating 2,000,000 records results in
+        two Parquet files. The test migrates the first with --max-parquet-files
+        equal to 1, then does a resume, migrating the second Parquet file.
+        """
+        current_time: pandas.Timestamp = pandas.Timestamp.now()
+
+        start_time = current_time - pandas.Timedelta(days=30)
+        assert isinstance(start_time, pandas.Timestamp)
+        end_time = start_time + pandas.Timedelta(days=1)
+        assert isinstance(end_time, pandas.Timestamp)
+
+        current_record_time = start_time
+
+        dimensions = [
+            {"Name": "hostname", "Value": "hostname1", "DimensionValueType": "VARCHAR"},
+            {"Name": "region", "Value": "us-west-2", "DimensionValueType": "VARCHAR"},
+            {"Name": "statat", "Value": "erwhile", "DimensionValueType": "VARCHAR"},
+            {"Name": "mono", "Value": "ter", "DimensionValueType": "VARCHAR"},
+            {"Name": "som", "Value": "lat", "DimensionValueType": "VARCHAR"},
+            {"Name": "cher", "Value": "tee", "DimensionValueType": "VARCHAR"},
+            {"Name": "no", "Value": "ma", "DimensionValueType": "VARCHAR"},
+            {"Name": "sine", "Value": "do", "DimensionValueType": "VARCHAR"},
+            {"Name": "reno", "Value": "badat", "DimensionValueType": "VARCHAR"},
+            {"Name": "sing", "Value": "lark", "DimensionValueType": "VARCHAR"},
+            {"Name": "bus", "Value": "tuff", "DimensionValueType": "VARCHAR"},
+        ]
+
+        print("Generating data")
+        records = []
+        for _ in range(2_000_000):
+            record = {
+                "Dimensions": dimensions,
+                "MeasureName": "cpu_utilization",
+                "MeasureValue": self.get_random_string(25),
+                "MeasureValueType": "VARCHAR",
+                "Time": str(current_record_time.value),
+                "TimeUnit": "NANOSECONDS",
+            }
+            records.append(record)
+            current_record_time = current_record_time + pandas.Timedelta(1, unit="ns")
+        self.put_records(records)
+
+        print("Migrating")
+        return_code = liveanalytics_influxdb3_migration_client.main(
+            [
+                "--live-analytics-database-name",
+                self.la_database_name,
+                "--s3-bucket-name",
+                self.s3_bucket_name,
+                "--max-parquet-files",
+                "1",
+            ]
+        )
+        # Since not all files are migrated, final verification will fail.
+        self.assertEqual(return_code, 1)
+
+        return_code = liveanalytics_influxdb3_migration_client.main(
+            [
+                "--live-analytics-database-name",
+                self.la_database_name,
+                "--s3-bucket-name",
+                self.s3_bucket_name,
+                "--resume",
+            ]
+        )
+        self.assertEqual(return_code, 0)
+
         la_table_count = self.check_live_analytics_table_count(
             database_name=self.la_database_name, table_name=self.la_table_name
         )

--- a/tools/python/liveanalytics_influxdb3_migration_plugin/liveanalytics_migration_client/tests/integration/test_liveanalytics_influxdb3_migration_client.py
+++ b/tools/python/liveanalytics_influxdb3_migration_plugin/liveanalytics_migration_client/tests/integration/test_liveanalytics_influxdb3_migration_client.py
@@ -364,11 +364,15 @@ class MigrationTestCase(unittest.TestCase):
             executor.map(self.post_records, batches)
 
     def post_records(self, batch):
-        self.timestream_write_client.write_records(
-            DatabaseName=self.la_database_name,
-            TableName=self.la_table_name,
-            Records=batch,
-        )
+        try:
+            self.timestream_write_client.write_records(
+                DatabaseName=self.la_database_name,
+                TableName=self.la_table_name,
+                Records=batch,
+            )
+        except Exception as e:
+            print(str(e))
+            raise
 
     @staticmethod
     def get_random_string(length: int):
@@ -441,6 +445,63 @@ class MigrationTestCase(unittest.TestCase):
             "Time": str(start_time.value),
             "TimeUnit": "NANOSECONDS",
         }
+        self.put_records([record])
+
+        return_code = liveanalytics_influxdb3_migration_client.main(
+            [
+                "--live-analytics-database-name",
+                self.la_database_name,
+                "--s3-bucket-name",
+                self.s3_bucket_name,
+            ]
+        )
+
+        self.assertEqual(return_code, 0)
+        la_table_count = self.check_live_analytics_table_count(
+            database_name=self.la_database_name, table_name=self.la_table_name
+        )
+        influxdb_v3_table_count = self.check_influxdb_v3_table_count(
+            database_name=self.influx_database, table_name=self.la_table_name
+        )
+        print(f"Table counts: {la_table_count}, {influxdb_v3_table_count}")
+        self.assertEqual(
+            la_table_count,
+            influxdb_v3_table_count,
+        )
+
+    def test_migration_basic_timestamps(self):
+        """
+        Tests basic migration of a single table where the table's only
+        record uses a timestamp as its measure value.
+        """
+        current_time: pandas.Timestamp = pandas.Timestamp.now()
+
+        start_time = current_time - pandas.Timedelta(days=30)
+        assert isinstance(start_time, pandas.Timestamp)
+        end_time = start_time + pandas.Timedelta(days=1)
+        assert isinstance(end_time, pandas.Timestamp)
+
+        dimensions = [
+            {"Name": "hostname", "Value": "hostname1", "DimensionValueType": "VARCHAR"},
+            {"Name": "region", "Value": "us-west-2", "DimensionValueType": "VARCHAR"},
+        ]
+
+        # Only multi-measure records can use TIMESTAMP as a measure type.
+        record = {
+            "Dimensions": dimensions,
+            "MeasureName": "cpu_utilization",
+            "MeasureValueType": "MULTI",
+            "Time": str(start_time.value),
+            "TimeUnit": "NANOSECONDS",
+            "MeasureValues": [
+                {
+                    "Name": "request_time",
+                    "Value": str(start_time.value),
+                    "Type": "TIMESTAMP",
+                }
+            ],
+        }
+
         self.put_records([record])
 
         return_code = liveanalytics_influxdb3_migration_client.main(
@@ -723,23 +784,66 @@ class MigrationTestCase(unittest.TestCase):
 
         current_record_time = start_time
 
-        dimensions = [
-            {"Name": "hostname", "Value": "hostname1", "DimensionValueType": "VARCHAR"},
-            {"Name": "region", "Value": "us-west-2", "DimensionValueType": "VARCHAR"},
-            {"Name": "statat", "Value": "erwhile", "DimensionValueType": "VARCHAR"},
-            {"Name": "mono", "Value": "ter", "DimensionValueType": "VARCHAR"},
-            {"Name": "som", "Value": "lat", "DimensionValueType": "VARCHAR"},
-            {"Name": "cher", "Value": "tee", "DimensionValueType": "VARCHAR"},
-            {"Name": "no", "Value": "ma", "DimensionValueType": "VARCHAR"},
-            {"Name": "sine", "Value": "do", "DimensionValueType": "VARCHAR"},
-            {"Name": "reno", "Value": "badat", "DimensionValueType": "VARCHAR"},
-            {"Name": "sing", "Value": "lark", "DimensionValueType": "VARCHAR"},
-            {"Name": "bus", "Value": "tuff", "DimensionValueType": "VARCHAR"},
-        ]
-
         print("Generating data")
         records = []
         for _ in range(2_000_000):
+            dimensions = [
+                {
+                    "Name": "hostname",
+                    "Value": self.get_random_string(12),
+                    "DimensionValueType": "VARCHAR",
+                },
+                {
+                    "Name": "region",
+                    "Value": self.get_random_string(18),
+                    "DimensionValueType": "VARCHAR",
+                },
+                {
+                    "Name": "statat",
+                    "Value": self.get_random_string(2),
+                    "DimensionValueType": "VARCHAR",
+                },
+                {
+                    "Name": "mono",
+                    "Value": self.get_random_string(25),
+                    "DimensionValueType": "VARCHAR",
+                },
+                {
+                    "Name": "som",
+                    "Value": self.get_random_string(10),
+                    "DimensionValueType": "VARCHAR",
+                },
+                {
+                    "Name": "cher",
+                    "Value": self.get_random_string(4),
+                    "DimensionValueType": "VARCHAR",
+                },
+                {
+                    "Name": "no",
+                    "Value": self.get_random_string(15),
+                    "DimensionValueType": "VARCHAR",
+                },
+                {
+                    "Name": "sine",
+                    "Value": self.get_random_string(26),
+                    "DimensionValueType": "VARCHAR",
+                },
+                {
+                    "Name": "reno",
+                    "Value": self.get_random_string(11),
+                    "DimensionValueType": "VARCHAR",
+                },
+                {
+                    "Name": "sing",
+                    "Value": self.get_random_string(6),
+                    "DimensionValueType": "VARCHAR",
+                },
+                {
+                    "Name": "bus",
+                    "Value": self.get_random_string(18),
+                    "DimensionValueType": "VARCHAR",
+                },
+            ]
             record = {
                 "Dimensions": dimensions,
                 "MeasureName": "cpu_utilization",

--- a/tools/python/liveanalytics_influxdb3_migration_plugin/liveanalytics_migration_client/tests/integration/test_liveanalytics_influxdb3_migration_client.py
+++ b/tools/python/liveanalytics_influxdb3_migration_plugin/liveanalytics_migration_client/tests/integration/test_liveanalytics_influxdb3_migration_client.py
@@ -651,6 +651,130 @@ class MigrationTestCase(unittest.TestCase):
             influxdb_v3_table_count,
         )
 
+    def test_migration_basic_resume_multiple_chunks(self):
+        """
+        Tests migrating multiple chunks with --resume.
+
+        This test will generate 3 chunks, assuming each chunk fits 99 days.
+        """
+        current_time: pandas.Timestamp = pandas.Timestamp.now()
+
+        start_time = current_time - pandas.Timedelta(days=200)
+        assert isinstance(start_time, pandas.Timestamp)
+        end_time = current_time
+        assert isinstance(end_time, pandas.Timestamp)
+
+        current_record_time = start_time
+
+        print("Generating data")
+        records = []
+        for _ in range(200):
+            dimensions = [
+                {
+                    "Name": "hostname",
+                    "Value": self.get_random_string(12),
+                    "DimensionValueType": "VARCHAR",
+                },
+                {
+                    "Name": "region",
+                    "Value": self.get_random_string(18),
+                    "DimensionValueType": "VARCHAR",
+                },
+                {
+                    "Name": "statat",
+                    "Value": self.get_random_string(2),
+                    "DimensionValueType": "VARCHAR",
+                },
+                {
+                    "Name": "mono",
+                    "Value": self.get_random_string(25),
+                    "DimensionValueType": "VARCHAR",
+                },
+                {
+                    "Name": "som",
+                    "Value": self.get_random_string(10),
+                    "DimensionValueType": "VARCHAR",
+                },
+                {
+                    "Name": "cher",
+                    "Value": self.get_random_string(4),
+                    "DimensionValueType": "VARCHAR",
+                },
+                {
+                    "Name": "no",
+                    "Value": self.get_random_string(15),
+                    "DimensionValueType": "VARCHAR",
+                },
+                {
+                    "Name": "sine",
+                    "Value": self.get_random_string(26),
+                    "DimensionValueType": "VARCHAR",
+                },
+                {
+                    "Name": "reno",
+                    "Value": self.get_random_string(11),
+                    "DimensionValueType": "VARCHAR",
+                },
+                {
+                    "Name": "sing",
+                    "Value": self.get_random_string(6),
+                    "DimensionValueType": "VARCHAR",
+                },
+                {
+                    "Name": "bus",
+                    "Value": self.get_random_string(18),
+                    "DimensionValueType": "VARCHAR",
+                },
+            ]
+            record = {
+                "Dimensions": dimensions,
+                "MeasureName": "cpu_utilization",
+                "MeasureValue": self.get_random_string(25),
+                "MeasureValueType": "VARCHAR",
+                "Time": str(current_record_time.value),
+                "TimeUnit": "NANOSECONDS",
+            }
+            records.append(record)
+            current_record_time = current_record_time + pandas.Timedelta(days=1)
+        self.put_records(records)
+
+        print("Migrating")
+        return_code = liveanalytics_influxdb3_migration_client.main(
+            [
+                "--live-analytics-database-name",
+                self.la_database_name,
+                "--s3-bucket-name",
+                self.s3_bucket_name,
+                "--max-parquet-files",
+                "1",
+            ]
+        )
+        # Since not all files are migrated, final verification will fail.
+        self.assertEqual(return_code, 1)
+
+        return_code = liveanalytics_influxdb3_migration_client.main(
+            [
+                "--live-analytics-database-name",
+                self.la_database_name,
+                "--s3-bucket-name",
+                self.s3_bucket_name,
+                "--resume",
+            ]
+        )
+        self.assertEqual(return_code, 0)
+
+        la_table_count = self.check_live_analytics_table_count(
+            database_name=self.la_database_name, table_name=self.la_table_name
+        )
+        influxdb_v3_table_count = self.check_influxdb_v3_table_count(
+            database_name=self.influx_database, table_name=self.la_table_name
+        )
+        print(f"Table counts: {la_table_count}, {influxdb_v3_table_count}")
+        self.assertEqual(
+            la_table_count,
+            influxdb_v3_table_count,
+        )
+
     def test_edge_case_migration(self):
         """
         Migrates all data from the test-data directory.

--- a/tools/python/liveanalytics_influxdb3_migration_plugin/liveanalytics_migration_plugin/liveanalytics_migration_plugin.py
+++ b/tools/python/liveanalytics_influxdb3_migration_plugin/liveanalytics_migration_plugin/liveanalytics_migration_plugin.py
@@ -198,6 +198,14 @@ def migrate_parquet_file(influxdb3_local, migration_id, db_name, current_parquet
 
     migration_records = influxdb3_local.cache.get("migration-records", default={})
 
+    if (
+        migration_records.get(current_parquet_path, {}).get("status")
+        == MIGRATION_COMPLETED
+    ):
+        return create_http_response(
+            HttpStatus.OK, "Parquet file was previously migrated, skipping migration"
+        )
+
     # Shared migration_records dict has not been populated. We will assume this is the
     # first invocation and populate it from the metadata table. The metadata table only exists for an hour.
     if not migration_records:
@@ -229,14 +237,6 @@ def migrate_parquet_file(influxdb3_local, migration_id, db_name, current_parquet
         error_message = f"{migration_id}: Migration failed: Parquet path {current_parquet_path} not found"
         influxdb3_local.error(error_message)
         return create_http_response(HttpStatus.NOT_FOUND, error_message)
-
-    if (
-        migration_records.get(current_parquet_path, {}).get("status")
-        == MIGRATION_COMPLETED
-    ):
-        return create_http_response(
-            HttpStatus.OK, "Parquet file was previously migrated, skipping migration"
-        )
 
     try:
         presigned_get_url = migration_records[current_parquet_path]["presigned_get_url"]

--- a/tools/python/liveanalytics_influxdb3_migration_plugin/liveanalytics_migration_plugin/liveanalytics_migration_plugin.py
+++ b/tools/python/liveanalytics_influxdb3_migration_plugin/liveanalytics_migration_plugin/liveanalytics_migration_plugin.py
@@ -167,7 +167,7 @@ def process_request(
             )
         deleted_table_counts = influxdb3_local.cache.delete("migration-table-counts")
         if deleted_table_counts:
-            influxdb3_local.info("Deleted table counts from in-memmory cache")
+            influxdb3_local.info("Deleted table counts from in-memory cache")
         else:
             influxdb3_local.error("Failed to delete table counts from in-memory cache")
         return response
@@ -185,7 +185,7 @@ def process_request(
             )
         deleted_table_counts = influxdb3_local.cache.delete("migration-table-counts")
         if deleted_table_counts:
-            influxdb3_local.info("Deleted table counts from in-memmory cache")
+            influxdb3_local.info("Deleted table counts from in-memory cache")
         else:
             return create_http_response(
                 HttpStatus.INTERNAL_ERROR,
@@ -216,9 +216,9 @@ def migrate_parquet_file(influxdb3_local, migration_id, db_name, current_parquet
         migration_records.get(current_parquet_path, {}).get("status")
         == MIGRATION_COMPLETED
     ):
-        return create_http_response(
-            HttpStatus.OK, "Parquet file was previously migrated, skipping migration"
-        )
+        message = f"Parquet file was previously migrated, skipping migration of {current_parquet_path}"
+        influxdb3_local.info(message)
+        return create_http_response(HttpStatus.OK, message)
 
     # Shared migration_records dict has not been populated. We will assume this is the
     # first invocation and populate it from the metadata table. The metadata table only exists for an hour.

--- a/tools/python/liveanalytics_influxdb3_migration_plugin/liveanalytics_migration_plugin/liveanalytics_migration_plugin.py
+++ b/tools/python/liveanalytics_influxdb3_migration_plugin/liveanalytics_migration_plugin/liveanalytics_migration_plugin.py
@@ -156,28 +156,42 @@ def process_request(
             HttpStatus.INVALID_REQUEST, f"Invalid argument: {str(e)}"
         )
 
-    if "verify" in query_parameters:
+    if "verify" in query_parameters and "delete_cache" in query_parameters:
         response = verify_previous_migrations(influxdb3_local, migration_id)
-        if "delete_cache" in query_parameters:
-            deleted_migration_records = influxdb3_local.cache.delete(
-                "migration-records"
+        deleted_migration_records = influxdb3_local.cache.delete("migration-records")
+        if deleted_migration_records:
+            influxdb3_local.info("Deleted migration records from in-memory cache")
+        else:
+            influxdb3_local.error(
+                "Failed to delete migration records from in-memory cache"
             )
-            if deleted_migration_records:
-                influxdb3_local.info("Deleted migration records from in-memory cache")
-            else:
-                influxdb3_local.error(
-                    "Failed to delete migration records from in-memory cache"
-                )
-            deleted_table_counts = influxdb3_local.cache.delete(
-                "migration-table-counts"
-            )
-            if deleted_table_counts:
-                influxdb3_local.info("Deleted table counts from in-memmory cache")
-            else:
-                influxdb3_local.error(
-                    "Failed to delete table counts from in-memory cache"
-                )
+        deleted_table_counts = influxdb3_local.cache.delete("migration-table-counts")
+        if deleted_table_counts:
+            influxdb3_local.info("Deleted table counts from in-memmory cache")
+        else:
+            influxdb3_local.error("Failed to delete table counts from in-memory cache")
         return response
+
+    if "verify" in query_parameters:
+        return verify_previous_migrations(influxdb3_local, migration_id)
+    if "delete_cache" in query_parameters:
+        deleted_migration_records = influxdb3_local.cache.delete("migration-records")
+        if deleted_migration_records:
+            influxdb3_local.info("Deleted migration records from in-memory cache")
+        else:
+            return create_http_response(
+                HttpStatus.INTERNAL_ERROR,
+                "Failed to delete migration records from in-memory cache",
+            )
+        deleted_table_counts = influxdb3_local.cache.delete("migration-table-counts")
+        if deleted_table_counts:
+            influxdb3_local.info("Deleted table counts from in-memmory cache")
+        else:
+            return create_http_response(
+                HttpStatus.INTERNAL_ERROR,
+                "Failed to delete table counts from in-memory cache",
+            )
+        return create_http_response(HttpStatus.OK, "Cache deleted")
 
     # Body of the incoming request.
     data = {}

--- a/tools/python/liveanalytics_influxdb3_migration_plugin/liveanalytics_migration_plugin/liveanalytics_migration_plugin.py
+++ b/tools/python/liveanalytics_influxdb3_migration_plugin/liveanalytics_migration_plugin/liveanalytics_migration_plugin.py
@@ -411,7 +411,7 @@ def verify_previous_migrations(influxdb3_local, migration_id):
                 migration_record["status"] = MIGRATION_FAILED
                 migration_records[parquet_path] = migration_record
                 influxdb3_local.cache.put(
-                    key=f"{migration_id}-records",
+                    key="migration-records",
                     value=migration_records,
                     ttl=CACHE_PUT_TTL_SECONDS,
                 )
@@ -422,12 +422,12 @@ def verify_previous_migrations(influxdb3_local, migration_id):
                 table_tally = table_counts.get(table_name, 0)
                 table_counts[table_name] = table_tally + current_parquet_row_count
                 influxdb3_local.cache.put(
-                    key=f"{migration_id}-table-counts",
+                    key="migration-table-counts",
                     value=table_counts,
                     ttl=CACHE_PUT_TTL_SECONDS,
                 )
                 influxdb3_local.cache.put(
-                    key=f"{migration_id}-records",
+                    key="migration-records",
                     value=migration_records,
                     ttl=CACHE_PUT_TTL_SECONDS,
                 )

--- a/tools/python/liveanalytics_influxdb3_migration_plugin/liveanalytics_migration_plugin/liveanalytics_migration_plugin.py
+++ b/tools/python/liveanalytics_influxdb3_migration_plugin/liveanalytics_migration_plugin/liveanalytics_migration_plugin.py
@@ -134,7 +134,7 @@ def process_request(
         response = verify_previous_migrations(influxdb3_local, migration_id)
         if "delete_cache" in query_parameters:
             deleted_migration_records = influxdb3_local.cache.delete(
-                f"{migration_id}-records"
+                "migration-records"
             )
             if deleted_migration_records:
                 influxdb3_local.info("Deleted migration records from in-memory cache")
@@ -143,7 +143,7 @@ def process_request(
                     "Failed to delete migration records from in-memory cache"
                 )
             deleted_table_counts = influxdb3_local.cache.delete(
-                f"{migration_id}-table-counts"
+                "migration-table-counts"
             )
             if deleted_table_counts:
                 influxdb3_local.info("Deleted table counts from in-memmory cache")
@@ -170,7 +170,7 @@ def migrate_parquet_file(influxdb3_local, migration_id, db_name, current_parquet
             HttpStatus.INVALID_REQUEST, "Invalid body, Parquet path is missing"
         )
 
-    migration_records = influxdb3_local.cache.get(f"{migration_id}-records", default={})
+    migration_records = influxdb3_local.cache.get("migration-records", default={})
 
     # Shared migration_records dict has not been populated. We will assume this is the
     # first invocation and populate it from the metadata table. The metadata table only exists for an hour.
@@ -180,7 +180,7 @@ def migrate_parquet_file(influxdb3_local, migration_id, db_name, current_parquet
         except Exception as e:
             return create_http_response(HttpStatus.INTERNAL_ERROR, str(e))
         influxdb3_local.cache.put(
-            key=f"{migration_id}-records",
+            key="migration-records",
             value=migration_records,
             ttl=CACHE_PUT_TTL_SECONDS,
         )
@@ -215,7 +215,7 @@ def migrate_parquet_file(influxdb3_local, migration_id, db_name, current_parquet
         )
         migration_records[current_parquet_path]["status"] = MIGRATION_NEEDS_VERIFICATION
         influxdb3_local.cache.put(
-            key=f"{migration_id}-records",
+            key="migration-records",
             value=migration_records,
             ttl=CACHE_PUT_TTL_SECONDS,
         )
@@ -269,8 +269,8 @@ def get_migration_metadata(influxdb3_local, migration_id):
 
 
 def verify_previous_migrations(influxdb3_local, migration_id):
-    migration_records = influxdb3_local.cache.get(f"{migration_id}-records", default={})
-    table_counts = influxdb3_local.cache.get(f"{migration_id}-table-counts", default={})
+    migration_records = influxdb3_local.cache.get("migration-records", default={})
+    table_counts = influxdb3_local.cache.get("migration-table-counts", default={})
 
     # Since influxdb3_local.write_to_db() writes to a buffer that is later ingested, each invocation must
     # verify the previous invocation's migration.
@@ -318,38 +318,46 @@ def verify_previous_migrations(influxdb3_local, migration_id):
 
             actual_row_count = query_response[0]["row_count"]
             if expected_row_count != actual_row_count:
-                error_message = f"{migration_id}: Migration failed for Parquet file {parquet_path}: expected {expected_row_count} rows, got {actual_row_count} rows"
-                influxdb3_local.error(error_message)
-                migration_record["status"] = MIGRATION_FAILED
-                migration_records[parquet_path] = migration_record
-                influxdb3_local.cache.put(
-                    key=f"{migration_id}-records",
-                    value=migration_records,
-                    ttl=CACHE_PUT_TTL_SECONDS,
-                )
-                return create_http_response(HttpStatus.INTERNAL_ERROR, error_message)
-            else:
-                migration_record["status"] = MIGRATION_COMPLETED
-                migration_records[parquet_path] = migration_record
-                table_counts[table_name] = expected_row_count
-                influxdb3_local.cache.put(
-                    key=f"{migration_id}-table-counts",
-                    value=table_counts,
-                    ttl=CACHE_PUT_TTL_SECONDS,
-                )
-                influxdb3_local.cache.put(
-                    key=f"{migration_id}-records",
-                    value=migration_records,
-                    ttl=CACHE_PUT_TTL_SECONDS,
-                )
-                put_done_file(
-                    influxdb3_local,
-                    parquet_path,
-                    migration_record["presigned_done_url"],
-                )
-                influxdb3_local.info(
-                    f"{migration_id}: Migration complete and verified for Parquet file {parquet_path}"
-                )
+                if expected_row_count < actual_row_count:
+                    influxdb3_local.warn(
+                        f"{migration_id}: Record mismatch: Expected {expected_row_count}, got {actual_row_count}"
+                    )
+                    migration_record["status"] = MIGRATION_COMPLETED
+                else:
+                    error_message = f"{migration_id}: Migration failed for Parquet file {parquet_path}: expected {expected_row_count} rows, got {actual_row_count} rows. Tally was {table_tally}"
+                    influxdb3_local.error(error_message)
+                    migration_record["status"] = MIGRATION_FAILED
+                    migration_records[parquet_path] = migration_record
+                    influxdb3_local.cache.put(
+                        key="migration-records",
+                        value=migration_records,
+                        ttl=CACHE_PUT_TTL_SECONDS,
+                    )
+                    return create_http_response(
+                        HttpStatus.INTERNAL_ERROR, error_message
+                    )
+            migration_record["status"] = MIGRATION_COMPLETED
+            migration_records[parquet_path] = migration_record
+            table_counts[table_name] = actual_row_count
+            influxdb3_local.cache.put(
+                key="migration-table-counts",
+                value=table_counts,
+                ttl=CACHE_PUT_TTL_SECONDS,
+            )
+            influxdb3_local.cache.put(
+                key="migration-records",
+                value=migration_records,
+                ttl=CACHE_PUT_TTL_SECONDS,
+            )
+            put_done_file(
+                influxdb3_local,
+                parquet_path,
+                migration_record["presigned_done_url"],
+            )
+            influxdb3_local.info(
+                f"{migration_id}: Migration complete and verified for Parquet file {parquet_path}"
+            )
+
         if migration_record["status"] != MIGRATION_COMPLETED:
             all_parquet_files_migrated = False
 

--- a/tools/python/liveanalytics_influxdb3_migration_plugin/liveanalytics_migration_plugin/liveanalytics_migration_plugin.py
+++ b/tools/python/liveanalytics_influxdb3_migration_plugin/liveanalytics_migration_plugin/liveanalytics_migration_plugin.py
@@ -18,6 +18,9 @@ MIGRATION_NEEDS_VERIFICATION = "needs verification"
 MIGRATION_COMPLETED = "completed"
 MIGRATION_FAILED = "failed"
 
+# 10 minutes.
+GET_PARQUET_TIMEOUT_SECONDS = 600
+
 # Items placed in the cache will stay for
 # seven days.
 CACHE_PUT_TTL_SECONDS = 604800
@@ -42,7 +45,11 @@ class PresignedRangeReader(io.RawIOBase):
         # Reuse session for connection pooling
         self.session = requests.Session()
 
-        head = self.session.get(self.url, headers={"Range": "bytes=0-0"})
+        head = self.session.get(
+            self.url,
+            headers={"Range": "bytes=0-0"},
+            timeout=GET_PARQUET_TIMEOUT_SECONDS,
+        )
         head.raise_for_status()
         self.length = int(head.headers["Content-Range"].split("/")[-1])
 
@@ -222,6 +229,14 @@ def migrate_parquet_file(influxdb3_local, migration_id, db_name, current_parquet
         error_message = f"{migration_id}: Migration failed: Parquet path {current_parquet_path} not found"
         influxdb3_local.error(error_message)
         return create_http_response(HttpStatus.NOT_FOUND, error_message)
+
+    if (
+        migration_records.get(current_parquet_path, {}).get("status")
+        == MIGRATION_COMPLETED
+    ):
+        return create_http_response(
+            HttpStatus.OK, "Parquet file was previously migrated, skipping migration"
+        )
 
     try:
         presigned_get_url = migration_records[current_parquet_path]["presigned_get_url"]

--- a/tools/python/liveanalytics_influxdb3_migration_plugin/liveanalytics_migration_plugin/liveanalytics_migration_plugin.py
+++ b/tools/python/liveanalytics_influxdb3_migration_plugin/liveanalytics_migration_plugin/liveanalytics_migration_plugin.py
@@ -105,12 +105,29 @@ class PresignedRangeReader(io.RawIOBase):
         return self.pos
 
 
-def create_http_response(status: HttpStatus, message: str):
+def create_http_response(status: HttpStatus, message: str, table_row_counts: dict = None):
+    """
+    Creates an HTTP response with sanitized message.
+    
+    Args:
+        status (HttpStatus): HTTP status code.
+        message (str): Response message.
+        table_row_counts (dict, optional): Dict mapping table names to expected cumulative row counts.
+    
+    Returns:
+        dict: Response with status, message, and optional table row counts.
+    """
     presigned_url_regex = r"(http|https)://.*"
     token_regex = r"apiv3_.*"
     sanitized_message = re.sub(presigned_url_regex, "*****", message)
     sanitized_message = re.sub(token_regex, "*****", sanitized_message)
-    return {"status": status, "message": sanitized_message}
+    response = {"status": status, "message": sanitized_message}
+    
+    # Include table row counts if provided (for client to verify at end of migration)
+    if table_row_counts is not None:
+        response["table_row_counts"] = table_row_counts
+    
+    return response
 
 
 def process_request(
@@ -206,7 +223,7 @@ def migrate_parquet_file(influxdb3_local, migration_id, db_name, current_parquet
 
     try:
         presigned_get_url = migration_records[current_parquet_path]["presigned_get_url"]
-        write_to_ingestion_buffer(
+        ingestion_stats = write_to_ingestion_buffer(
             influxdb3_local=influxdb3_local,
             migration_id=migration_id,
             db_name=db_name,
@@ -214,6 +231,11 @@ def migrate_parquet_file(influxdb3_local, migration_id, db_name, current_parquet
             parquet_path=current_parquet_path,
         )
         migration_records[current_parquet_path]["status"] = MIGRATION_NEEDS_VERIFICATION
+        # Store ingestion stats (row count and time bounds) for efficient verification later
+        # This avoids having to re-read the parquet file from S3 during verification
+        migration_records[current_parquet_path]["row_count"] = ingestion_stats["row_count"]
+        migration_records[current_parquet_path]["min_time_ns"] = ingestion_stats["min_time_ns"]
+        migration_records[current_parquet_path]["max_time_ns"] = ingestion_stats["max_time_ns"]
         influxdb3_local.cache.put(
             key=f"{migration_id}-records",
             value=migration_records,
@@ -300,25 +322,82 @@ def verify_previous_migrations(influxdb3_local, migration_id):
                     "Parquet file path was incorrectly formatted. Path should start wtih database-name/table-name",
                 )
             table_name = table_name_parts[1]
-            reader = PresignedRangeReader(migration_record["presigned_get_url"])
-            parquet_file = pq.ParquetFile(reader)
-
-            # Multiple Parquet files may be migrated to the same table. For proper verification, we need to keep a
-            # tally of the table row count, taking into account all previously ingested data.
-            current_parquet_row_count = parquet_file.metadata.num_rows
-            table_tally = table_counts.get(table_name, 0)
-            expected_row_count = table_tally + current_parquet_row_count
-            row_count_query = f'SELECT COUNT(*) AS row_count FROM "{table_name}"'
-            query_response = influxdb3_local.query(row_count_query)
-
-            if not query_response:
-                error_message = f"{migration_id}: Unable to verify record count for table {table_name} from Parquet file {parquet_path}"
+            
+            # Get row count and time bounds from cache stored during previous file ingestion
+            current_parquet_row_count = migration_record.get("row_count")
+            min_time_ns = migration_record.get("min_time_ns")
+            max_time_ns = migration_record.get("max_time_ns")
+            
+            if current_parquet_row_count is None:
+                error_message = (
+                    f"{migration_id}: Row count not in cache for {parquet_path}. "
+                    f"This file was not properly ingested - cache entry missing row_count."
+                )
                 influxdb3_local.error(error_message)
                 return create_http_response(HttpStatus.INTERNAL_ERROR, error_message)
+            
+            if min_time_ns is None or max_time_ns is None:
+                error_message = (
+                    f"{migration_id}: Time bounds not in cache for {parquet_path}. "
+                    f"This file was not properly ingested - cache entry missing time bounds."
+                )
+                influxdb3_local.error(error_message)
+                return create_http_response(HttpStatus.INTERNAL_ERROR, error_message)
+            
+            # Convert nanoseconds to RFC3339 timestamp for InfluxDB query
+            min_time_str = pandas.Timestamp(min_time_ns, unit='ns').isoformat() + "Z"
+            max_time_str = pandas.Timestamp(max_time_ns, unit='ns').isoformat() + "Z"
+            
+            row_count_query = (
+                f'SELECT COUNT(*) AS row_count FROM "{table_name}" '
+                f"WHERE time >= '{min_time_str}' AND time <= '{max_time_str}'"
+            )
+            expected_row_count = current_parquet_row_count
+            influxdb3_local.info(
+                f"{migration_id}: Verifying {parquet_path} with time-bounded query "
+                f"(time range: {min_time_str} to {max_time_str}, expected {expected_row_count} rows)"
+            )
+                
+            # Verify row count with retry logic to handle WAL flush timing
+            max_verification_attempts = 3
+            verification_retry_delay_seconds = 5
+            actual_row_count = None
+            
+            for attempt in range(max_verification_attempts):
+                query_response = influxdb3_local.query(row_count_query)
 
-            actual_row_count = query_response[0]["row_count"]
-            if expected_row_count != actual_row_count:
-                error_message = f"{migration_id}: Migration failed for Parquet file {parquet_path}: expected {expected_row_count} rows, got {actual_row_count} rows"
+                if not query_response:
+                    error_message = f"{migration_id}: Unable to verify record count for table {table_name} from Parquet file {parquet_path}"
+                    influxdb3_local.error(error_message)
+                    return create_http_response(HttpStatus.INTERNAL_ERROR, error_message)
+
+                actual_row_count = query_response[0]["row_count"]
+                
+                # For time-bounded queries: actual >= expected is success
+                # because other parquet files may have overlapping time ranges.
+                # Timestream UNLOAD doesn't guarantee non-overlapping timestamps.
+                # Only fail if actual < expected (data is missing).
+                if actual_row_count >= expected_row_count:
+                    # Verification passed
+                    if actual_row_count > expected_row_count:
+                        influxdb3_local.info(
+                            f"{migration_id}: Verification passed for {parquet_path}. "
+                            f"Got {actual_row_count} rows (>= expected {expected_row_count}). "
+                            f"Extra rows likely from overlapping time ranges in other parquet files."
+                        )
+                    break
+                elif attempt < max_verification_attempts - 1:
+                    # Row count less than expected - WAL may not have flushed yet, retry after delay
+                    influxdb3_local.info(
+                        f"{migration_id}: Row count less than expected for {parquet_path} "
+                        f"(expected {expected_row_count}, got {actual_row_count}). "
+                        f"Waiting {verification_retry_delay_seconds}s for WAL flush... "
+                        f"(attempt {attempt + 1}/{max_verification_attempts})"
+                    )
+                    time.sleep(verification_retry_delay_seconds)
+            
+            if actual_row_count < expected_row_count:
+                error_message = f"{migration_id}: Migration failed for Parquet file {parquet_path}: expected at least {expected_row_count} rows, got {actual_row_count} rows (after {max_verification_attempts} attempts)"
                 influxdb3_local.error(error_message)
                 migration_record["status"] = MIGRATION_FAILED
                 migration_records[parquet_path] = migration_record
@@ -331,7 +410,9 @@ def verify_previous_migrations(influxdb3_local, migration_id):
             else:
                 migration_record["status"] = MIGRATION_COMPLETED
                 migration_records[parquet_path] = migration_record
-                table_counts[table_name] = expected_row_count
+                # Update cumulative table count for potential fallback scenarios
+                table_tally = table_counts.get(table_name, 0)
+                table_counts[table_name] = table_tally + current_parquet_row_count
                 influxdb3_local.cache.put(
                     key=f"{migration_id}-table-counts",
                     value=table_counts,
@@ -356,16 +437,31 @@ def verify_previous_migrations(influxdb3_local, migration_id):
     if all_parquet_files_migrated:
         success_message = f"{migration_id}: All Parquet files migrated"
         influxdb3_local.info(success_message)
-        return create_http_response(HttpStatus.OK, success_message)
+        # Return final table row counts for client to verify against InfluxDB
+        return create_http_response(HttpStatus.OK, success_message, table_row_counts=table_counts)
     return create_http_response(
         HttpStatus.ACCEPTED,
         "Verified outstanding migrations. Migrations are still in progress or pending verification",
+        table_row_counts=table_counts,
     )
 
 
 def write_to_ingestion_buffer(
     influxdb3_local, migration_id, db_name, presigned_get_url, parquet_path
 ):
+    """
+    Writes parquet data to the InfluxDB ingestion buffer.
+    
+    Args:
+        influxdb3_local: InfluxDB v3 local client.
+        migration_id (str): The migration ID.
+        db_name (str): Database name.
+        presigned_get_url (str): Pre-signed GET URL for the Parquet file.
+        parquet_path (str): S3 path to the parquet file.
+        
+    Returns:
+        dict: Ingestion statistics including row_count, min_time_ns, max_time_ns
+    """
     influxdb3_local.info(f"{migration_id}: Starting migration")
 
     # Assuming Parquet path, within S3 bucket, is organized as database-name/table-name/results/. . .
@@ -377,10 +473,11 @@ def write_to_ingestion_buffer(
             "Parquet file path was incorrectly formatted. Path should start wtih database-name/table-name"
         )
     table_name = table_name_parts[1]
-    ingest_parquet_file_in_chunks(
+    ingestion_stats = ingest_parquet_file_in_chunks(
         influxdb3_local, presigned_get_url, db_name, table_name, parquet_path
     )
     influxdb3_local.info(f"{migration_id}: Wrote {parquet_path} to buffer")
+    return ingestion_stats
 
 
 def put_done_file(influxdb3_local, s3_key: str, presigned_done_url: str):
@@ -408,7 +505,7 @@ def put_done_file(influxdb3_local, s3_key: str, presigned_done_url: str):
 
 
 def read_parquet_in_batches(
-    influxdb3_local, presigned_get_url: str, s3_key: str, batch_size: int = 20000
+    influxdb3_local, presigned_get_url: str, s3_key: str, batch_size
 ):
     reader = PresignedRangeReader(presigned_get_url)
     parquet_file = pq.ParquetFile(reader)
@@ -432,7 +529,7 @@ def ingest_parquet_file_in_chunks(
     db_name: str,
     table_name: str,
     s3_key: str,
-    chunk_size: int = 10000,
+    chunk_size: int = 2000,
 ):
     """
     Read parquet file in chunks and format output as requested.
@@ -447,7 +544,7 @@ def ingest_parquet_file_in_chunks(
         chunk_size (int): Number of records to read at a time (default: 10000).
 
     Returns:
-        None
+        dict: Ingestion statistics including row_count, min_time_ns, max_time_ns
     """
 
     influxdb3_local.info("Processing Parquet files in chunks")
@@ -457,13 +554,18 @@ def ingest_parquet_file_in_chunks(
     records_processed = 0
     chunk_number = 0
     processing_start_time = time.time()
+    
+    # Track time bounds during ingestion for efficient verification later
+    min_time_ns = None
+    max_time_ns = None
 
     # Read the file in batches.
-    for batch in read_parquet_in_batches(influxdb3_local, presigned_get_url, s3_key):
+    for batch in read_parquet_in_batches(influxdb3_local, presigned_get_url, s3_key, chunk_size):
         chunk_number += 1
         batch_schema = batch.schema
         column_types = []
-        for field in batch_schema:
+        time_col_idx = None
+        for idx, field in enumerate(batch_schema):
             # We only care about double and int64 as other panda data types can be inferred during line protocol generation
             if pa.types.is_floating(field.type):
                 column_types.append(("double", field.name))
@@ -471,7 +573,23 @@ def ingest_parquet_file_in_chunks(
                 column_types.append(("int64", field.name))
             else:
                 column_types.append(("skip", field.name))
+            if field.name.lower() == "time":
+                time_col_idx = idx
+        
         df_chunk = batch.to_pandas(types_mapper={pa.int64(): pandas.Int64Dtype()}.get)
+        
+        # Track min/max time from this batch for verification
+        if time_col_idx is not None and "time" in df_chunk.columns:
+            batch_min = df_chunk["time"].min()
+            batch_max = df_chunk["time"].max()
+            if pandas.notna(batch_min):
+                batch_min_ns = pandas.Timestamp(batch_min).value
+                if min_time_ns is None or batch_min_ns < min_time_ns:
+                    min_time_ns = batch_min_ns
+            if pandas.notna(batch_max):
+                batch_max_ns = pandas.Timestamp(batch_max).value
+                if max_time_ns is None or batch_max_ns > max_time_ns:
+                    max_time_ns = batch_max_ns
 
         influxdb3_local.info(
             f"Processing Chunk {chunk_number} ({len(df_chunk):,} records)"
@@ -508,6 +626,13 @@ def ingest_parquet_file_in_chunks(
     influxdb3_local.info(
         f"Processing rate: {records_processed / processing_time:.0f} records/second"
     )
+    
+    # Return stats for verification
+    return {
+        "row_count": records_processed,
+        "min_time_ns": min_time_ns,
+        "max_time_ns": max_time_ns,
+    }
 
 
 def transform_row_to_lp(influxdb3_local, row, table_name, column_types):
@@ -578,3 +703,4 @@ def parse_arg(influxdb3_local, arg_key, args):
     error_message = f"{arg_key} not supplied in args"
     influxdb3_local.error(error_message)
     raise RuntimeError(error_message)
+

--- a/tools/python/liveanalytics_influxdb3_migration_plugin/liveanalytics_migration_plugin/liveanalytics_migration_plugin.py
+++ b/tools/python/liveanalytics_influxdb3_migration_plugin/liveanalytics_migration_plugin/liveanalytics_migration_plugin.py
@@ -105,15 +105,17 @@ class PresignedRangeReader(io.RawIOBase):
         return self.pos
 
 
-def create_http_response(status: HttpStatus, message: str, table_row_counts: dict = None):
+def create_http_response(
+    status: HttpStatus, message: str, table_row_counts: dict = None
+):
     """
     Creates an HTTP response with sanitized message.
-    
+
     Args:
         status (HttpStatus): HTTP status code.
         message (str): Response message.
         table_row_counts (dict, optional): Dict mapping table names to expected cumulative row counts.
-    
+
     Returns:
         dict: Response with status, message, and optional table row counts.
     """
@@ -122,11 +124,11 @@ def create_http_response(status: HttpStatus, message: str, table_row_counts: dic
     sanitized_message = re.sub(presigned_url_regex, "*****", message)
     sanitized_message = re.sub(token_regex, "*****", sanitized_message)
     response = {"status": status, "message": sanitized_message}
-    
+
     # Include table row counts if provided (for client to verify at end of migration)
     if table_row_counts is not None:
         response["table_row_counts"] = table_row_counts
-    
+
     return response
 
 
@@ -232,9 +234,15 @@ def migrate_parquet_file(influxdb3_local, migration_id, db_name, current_parquet
         )
         migration_records[current_parquet_path]["status"] = MIGRATION_NEEDS_VERIFICATION
         # Store ingestion stats (row count and time bounds) for row count verification
-        migration_records[current_parquet_path]["row_count"] = ingestion_stats["row_count"]
-        migration_records[current_parquet_path]["min_time_ns"] = ingestion_stats["min_time_ns"]
-        migration_records[current_parquet_path]["max_time_ns"] = ingestion_stats["max_time_ns"]
+        migration_records[current_parquet_path]["row_count"] = ingestion_stats[
+            "row_count"
+        ]
+        migration_records[current_parquet_path]["min_time_ns"] = ingestion_stats[
+            "min_time_ns"
+        ]
+        migration_records[current_parquet_path]["max_time_ns"] = ingestion_stats[
+            "max_time_ns"
+        ]
         influxdb3_local.cache.put(
             key="migration-records",
             value=migration_records,
@@ -321,12 +329,12 @@ def verify_previous_migrations(influxdb3_local, migration_id):
                     "Parquet file path was incorrectly formatted. Path should start wtih database-name/table-name",
                 )
             table_name = table_name_parts[1]
-            
+
             # Get row count and time bounds from cache stored during previous file ingestion
             current_parquet_row_count = migration_record.get("row_count")
             min_time_ns = migration_record.get("min_time_ns")
             max_time_ns = migration_record.get("max_time_ns")
-            
+
             if current_parquet_row_count is None:
                 error_message = (
                     f"{migration_id}: Row count not in cache for {parquet_path}. "
@@ -334,7 +342,7 @@ def verify_previous_migrations(influxdb3_local, migration_id):
                 )
                 influxdb3_local.error(error_message)
                 return create_http_response(HttpStatus.INTERNAL_ERROR, error_message)
-            
+
             if min_time_ns is None or max_time_ns is None:
                 error_message = (
                     f"{migration_id}: Time bounds not in cache for {parquet_path}. "
@@ -342,11 +350,11 @@ def verify_previous_migrations(influxdb3_local, migration_id):
                 )
                 influxdb3_local.error(error_message)
                 return create_http_response(HttpStatus.INTERNAL_ERROR, error_message)
-            
+
             # Convert nanoseconds to RFC3339 timestamp for InfluxDB query
-            min_time_str = pandas.Timestamp(min_time_ns, unit='ns').isoformat() + "Z"
-            max_time_str = pandas.Timestamp(max_time_ns, unit='ns').isoformat() + "Z"
-            
+            min_time_str = pandas.Timestamp(min_time_ns, unit="ns").isoformat() + "Z"
+            max_time_str = pandas.Timestamp(max_time_ns, unit="ns").isoformat() + "Z"
+
             row_count_query = (
                 f'SELECT COUNT(*) AS row_count FROM "{table_name}" '
                 f"WHERE time >= '{min_time_str}' AND time <= '{max_time_str}'"
@@ -356,22 +364,24 @@ def verify_previous_migrations(influxdb3_local, migration_id):
                 f"{migration_id}: Verifying {parquet_path} with time-bounded query "
                 f"(time range: {min_time_str} to {max_time_str}, expected {expected_row_count} rows)"
             )
-                
+
             # Verify row count with retry logic to handle WAL flush timing
             max_verification_attempts = 3
             verification_retry_delay_seconds = 5
             actual_row_count = None
-            
+
             for attempt in range(max_verification_attempts):
                 query_response = influxdb3_local.query(row_count_query)
 
                 if not query_response:
                     error_message = f"{migration_id}: Unable to verify record count for table {table_name} from Parquet file {parquet_path}"
                     influxdb3_local.error(error_message)
-                    return create_http_response(HttpStatus.INTERNAL_ERROR, error_message)
+                    return create_http_response(
+                        HttpStatus.INTERNAL_ERROR, error_message
+                    )
 
                 actual_row_count = query_response[0]["row_count"]
-                
+
                 # For time-bounded queries: actual >= expected is success
                 # because other parquet files may have overlapping time ranges
                 # Timestream UNLOAD doesn't guarantee non-overlapping timestamps
@@ -394,7 +404,7 @@ def verify_previous_migrations(influxdb3_local, migration_id):
                         f"(attempt {attempt + 1}/{max_verification_attempts})"
                     )
                     time.sleep(verification_retry_delay_seconds)
-            
+
             if actual_row_count < expected_row_count:
                 error_message = f"{migration_id}: Migration failed for Parquet file {parquet_path}: expected at least {expected_row_count} rows, got {actual_row_count} rows (after {max_verification_attempts} attempts)"
                 influxdb3_local.error(error_message)
@@ -436,7 +446,9 @@ def verify_previous_migrations(influxdb3_local, migration_id):
         success_message = f"{migration_id}: All Parquet files migrated"
         influxdb3_local.info(success_message)
         # Return final table row counts for client to verify against InfluxDB
-        return create_http_response(HttpStatus.OK, success_message, table_row_counts=table_counts)
+        return create_http_response(
+            HttpStatus.OK, success_message, table_row_counts=table_counts
+        )
     return create_http_response(
         HttpStatus.ACCEPTED,
         "Verified outstanding migrations. Migrations are still in progress or pending verification",
@@ -449,14 +461,14 @@ def write_to_ingestion_buffer(
 ):
     """
     Writes parquet data to the InfluxDB ingestion buffer.
-    
+
     Args:
         influxdb3_local: InfluxDB v3 local client.
         migration_id (str): The migration ID.
         db_name (str): Database name.
         presigned_get_url (str): Pre-signed GET URL for the Parquet file.
         parquet_path (str): S3 path to the parquet file.
-        
+
     Returns:
         dict: Ingestion statistics including row_count, min_time_ns, max_time_ns
     """
@@ -552,12 +564,14 @@ def ingest_parquet_file_in_chunks(
     records_processed = 0
     chunk_number = 0
     processing_start_time = time.time()
-    
+
     min_time_ns = None
     max_time_ns = None
 
     # Read the file in batches.
-    for batch in read_parquet_in_batches(influxdb3_local, presigned_get_url, s3_key, chunk_size):
+    for batch in read_parquet_in_batches(
+        influxdb3_local, presigned_get_url, s3_key, chunk_size
+    ):
         chunk_number += 1
         batch_schema = batch.schema
         column_types = []
@@ -572,9 +586,9 @@ def ingest_parquet_file_in_chunks(
                 column_types.append(("skip", field.name))
             if field.name.lower() == "time":
                 time_col_idx = idx
-        
+
         df_chunk = batch.to_pandas(types_mapper={pa.int64(): pandas.Int64Dtype()}.get)
-        
+
         # Track min/max time from this batch for verification
         if time_col_idx is not None and "time" in df_chunk.columns:
             batch_min = df_chunk["time"].min()
@@ -623,7 +637,7 @@ def ingest_parquet_file_in_chunks(
     influxdb3_local.info(
         f"Processing rate: {records_processed / processing_time:.0f} records/second"
     )
-    
+
     return {
         "row_count": records_processed,
         "min_time_ns": min_time_ns,
@@ -699,4 +713,3 @@ def parse_arg(influxdb3_local, arg_key, args):
     error_message = f"{arg_key} not supplied in args"
     influxdb3_local.error(error_message)
     raise RuntimeError(error_message)
-


### PR DESCRIPTION
*Issue #, if available:*

N/A.

*Description of changes:*

- Resume functionality with multiple Parquet files has been fixed.
- A large resume test has been added that migrates 2,000,000 records.
- A new `--max-parquet-files` option has been added to set the maximum number of Parquet files that are migrated.
- Inside the plugin, migration IDs are no longer used in the cache. This means multiple invocations use the same cached values.
- UNLOAD queries are checked for completion.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
