### PR TITLE
Adding batch writing for metadata with the LiveAnalytics InfluxDB migration plugin

### DIFF
--- a/tools/python/liveanalytics_influxdb3_migration_plugin/README.md
+++ b/tools/python/liveanalytics_influxdb3_migration_plugin/README.md
@@ -50,7 +50,12 @@ The overall migration process is as follows:
 2. After meeting the pre-requisites, the client is run and provided with a Timestream for LiveAnalytics database to migrate; the InfluxDB v3 host, token, and database name as environment variables; and the name of an [Amazon S3](https://aws.amazon.com/s3/) bucket.
 3. The client sends a query to Timestream for LiveAnalytics, unloading all data in the database into the S3 bucket in the form of Parquet files. Parquet files are organized into `s3://<bucket name>/<database name>/<table name>` object keys.
 4. The client creates a metadata table in InfluxDB v3. This metadata table is used as a work queue by the plugin.
-5. The client generates [presigned URLs](https://docs.aws.amazon.com/AmazonS3/latest/userguide/ShareObjectPreSignedURL.html) for all Parquet files in the S3 bucket. Additionally, presigned PUT URLs are generated so that the plugin can mark a file as having been migrated. This is done by putting an empty `done.ack` file, using a Parquet file's name as an object key. For example, `s3://<bucket name>/<database name>/<table name>/example.parquet/done.ack`. Presigned URLs are given a maximum expiration date of 7 days.
+5. The client generates [presigned URLs](https://docs.aws.amazon.com/AmazonS3/latest/userguide/ShareObjectPreSignedURL.html) for all Parquet files in the S3 bucket. Additionally, presigned PUT URLs are generated so that the plugin can mark a file as having been migrated. This is done by putting an empty `done.ack` file, using a Parquet file's name as an object key. For example, `s3://<bucket name>/<database name>/<table name>/example.parquet/done.ack`. Presigned URLs are given a maximum expiration date which is summarized below:
+
+- Default EC2 instance: ~6 hours max
+- With AssumeRole: up to 12 hours max
+- For 7 days: must use IAM user access keys
+
 6. The client places all presigned URLs in the metadata table so that the plugin can use them.
 7. The client creates an HTTP trigger with arguments specifying the S3 bucket name, database name, and a unique migration ID.
 8. The client, using the HTTP trigger, sends a request for each Parquet file. Since the plugin writes to a buffer and does not persist writes, each invocation of the trigger verifies the previous migration. When an invocation verifies a previous migration, it places an empty `done.ack` file in the S3 bucket, marking that Parquet file as completed, preventing it from being migrated if `--resume` is used in the future.

--- a/tools/python/liveanalytics_influxdb3_migration_plugin/README.md
+++ b/tools/python/liveanalytics_influxdb3_migration_plugin/README.md
@@ -106,42 +106,62 @@ Before starting a migration, the following prerequisites must be met:
 
     ```json
     {
-        "Sid": "QueryLiveAnalytics",
-        "Effect": "Allow",
-        "Action": [
-           "timestream:Select",
-           "timestream:DescribeEndpoints",
-           "timestream:ListDatabases",
-           "timestream:ListTables",
-           "timestream:DescribeDatabase",
-           "timestream:DescribeTable",
-           "timestream:SelectValues"
-        ],
-        "Resource": "*"
-    },
-    {
-       "Sid": "MigrationDataBucketMetadata",
-       "Effect": "Allow",
-       "Action": [
-          "s3:ListBucket",
-          "s3:GetBucketLocation",
-          "s3:GetBucketVersioning"
-       ],
-       "Resource": "arn:aws:s3:::LAtoV3MigrationDataBucket-*"
-    },
-    {
-       "Sid": "AccessDataBucket",
-       "Effect": "Allow",
-       "Action": [
-          "s3:GetObject",
-          "s3:PutObject",
-          "s3:DeleteObject",
-          "s3:PutObjectLegalHold",
-          "s3:DeleteObject",
-          "s3:DeleteObjectVersion",
-          "s3:BypassGovernanceRetention"
-       ],
-       "Resource": "arn:aws:s3:::LAtoV3MigrationDataBucket-*/*"
+        "Version": "2012-10-17",
+        "Statement": [
+            {
+                "Sid": "DescribeLiveAnalytics",
+                "Effect": "Allow",
+                "Action": [
+                    "timestream:DescribeEndpoints",
+                    "timestream:ListDatabases"
+                ],
+                "Resource": "*"
+            },
+            {
+                "Sid": "QueryLiveAnalytics",
+                "Effect": "Allow",
+                "Action": [
+                    "timestream:Select",
+                    "timestream:ListTables",
+                    "timestream:DescribeDatabase",
+                    "timestream:DescribeTable",
+                    "timestream:SelectValues",
+                    "timestream:unload"
+                ],
+                "Resource": [
+                    "arn:aws:timestream:<aws region>:<account id>:database/<database name>/*",
+                    "arn:aws:timestream:<aws region>:<account id>:database/<database name>"
+                ]
+            },
+            {
+                "Sid": "MigrationDataBucketMetadata",
+                "Effect": "Allow",
+                "Action": [
+                    "s3:ListBucket",
+                    "s3:GetBucketLocation",
+                    "s3:GetBucketAcl",
+                    "s3:GetBucketVersioning",
+                    "s3:GetBucketObjectLockConfiguration",
+                    "s3:GetEncryptionConfiguration",
+                    "s3:GetBucketPolicy"
+                ],
+                "Resource": "arn:aws:s3:::<bucket name>"
+            },
+            {
+                "Sid": "AccessDataBucket",
+                "Effect": "Allow",
+                "Action": [
+                    "s3:GetObject",
+                    "s3:PutObject",
+                    "s3:DeleteObject",
+                    "s3:PutObjectLegalHold",
+                    "s3:DeleteObject",
+                    "s3:DeleteObjectVersion",
+                    "s3:BypassGovernanceRetention"
+                ],
+                "Resource": "arn:aws:s3:::<bucket name>/*"
+            }
+        ]
     }
     ```
 

--- a/tools/python/liveanalytics_influxdb3_migration_plugin/README.md
+++ b/tools/python/liveanalytics_influxdb3_migration_plugin/README.md
@@ -126,7 +126,7 @@ Before starting a migration, the following prerequisites must be met:
                     "timestream:DescribeDatabase",
                     "timestream:DescribeTable",
                     "timestream:SelectValues",
-                    "timestream:unload"
+                    "timestream:Unload"
                 ],
                 "Resource": [
                     "arn:aws:timestream:<aws region>:<account id>:database/<database name>/*",

--- a/tools/python/liveanalytics_influxdb3_migration_plugin/liveanalytics_migration_client/liveanalytics_influxdb3_migration_client.py
+++ b/tools/python/liveanalytics_influxdb3_migration_plugin/liveanalytics_migration_client/liveanalytics_influxdb3_migration_client.py
@@ -25,6 +25,8 @@ from datetime import datetime, timezone
 MIGRATION_METADATA_TABLE: str = "liveanalytics_migration_metadata"
 TRIGGER_NAME: str = "migration_trigger"
 UNLOAD_WAIT_SECONDS: int = 10
+# InfluxDB has a 10MB max request size, using 8MB as a safe limit.
+INFLUXDB_MAX_WRITE_BATCH_BYTES: int = 8 * 1024 * 1024
 
 
 class InfluxDBMigrationWrapper:
@@ -717,6 +719,7 @@ class InfluxDBMigrationWrapper:
     def write_metadata_to_influxdb(self, metadata):
         """
         Writes metadata to InfluxDB v3 using line protocol.
+        Automatically batches writes to stay under the InfluxDB max request size limit.
 
         Args:
             metadata (dict[str, dict[str, str]]): Mapping of random UUIDs to a file's
@@ -727,23 +730,57 @@ class InfluxDBMigrationWrapper:
         """
         try:
             self.info("Writing metadata to InfluxDB")
-            lines: list[str] = []
+
+            current_batch: list[str] = []
+            current_batch_size: int = 0
+            batch_number: int = 0
+            total_entries_written: int = 0
 
             for s3_key, migration_metadata in metadata.items():
-                lines.append(
+                line = (
                     f"{MIGRATION_METADATA_TABLE},"
                     f"s3_key={s3_key} "
                     f'presigned_get_url="{migration_metadata["presigned_get_url"]}",'
                     f'presigned_done_url="{migration_metadata["presigned_done_url"]}"\n'
                 )
+                line_size = len(line.encode("utf-8"))
 
-            self.influxdb_client.write(
-                database=self.influx_database,
-                record=lines,
-                write_precision=WritePrecision.NS,
-            )
+                # If adding this line would exceed the batch limit, write current batch first
+                if (
+                    current_batch_size + line_size > INFLUXDB_MAX_WRITE_BATCH_BYTES
+                    and current_batch
+                ):
+                    batch_number += 1
+                    self.info(
+                        f"Writing metadata batch {batch_number} ({len(current_batch)} entries, {current_batch_size:,} bytes)"
+                    )
+                    self.influxdb_client.write(
+                        database=self.influx_database,
+                        record=current_batch,
+                        write_precision=WritePrecision.NS,
+                    )
+                    total_entries_written += len(current_batch)
+                    current_batch = []
+                    current_batch_size = 0
+
+                current_batch.append(line)
+                current_batch_size += line_size
+
+            # Write any remaining entries in the final batch
+            if current_batch:
+                batch_number += 1
+                self.info(
+                    f"Writing metadata batch {batch_number} ({len(current_batch)} entries, {current_batch_size:,} bytes)"
+                )
+                self.influxdb_client.write(
+                    database=self.influx_database,
+                    record=current_batch,
+                    write_precision=WritePrecision.NS,
+                )
+                total_entries_written += len(current_batch)
+
             self.info(
-                f"Successfully wrote {len(metadata)} metadata entries to InfluxDB"
+                f"Successfully wrote {total_entries_written} metadata entries to InfluxDB in {batch_number} batch(es)"
             )
 
         except Exception as e:
@@ -1425,3 +1462,4 @@ Examples:
 
 if __name__ == "__main__":
     main(sys.argv[1:])
+


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

- For large migrations, the presigned URLs written to the metadata table are now batched to not exceed 10MB threshold per request with InfluxDB 3
- Revising policy to allow invocation and perform migrations from LiveAnalytics to InfluxDB 3 using the migration plugin.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
